### PR TITLE
Fix undefined error when adding scoped package on yarn, npm or npx

### DIFF
--- a/src/packagemanager/npm/parsing/parsePackagesFromInstallArgs.js
+++ b/src/packagemanager/npm/parsing/parsePackagesFromInstallArgs.js
@@ -86,7 +86,9 @@ function parsePackagename(arg) {
   const lastAtIndex = arg.lastIndexOf("@");
 
   let name, version;
-  if (lastAtIndex !== -1) {
+  // The index of the last "@" should be greater than 0
+  // If the index is 0, it means the package name starts with "@" (eg: "@vercel/otel")
+  if (lastAtIndex > 0) {
     name = arg.slice(0, lastAtIndex);
     version = arg.slice(lastAtIndex + 1);
   } else {

--- a/src/packagemanager/npm/parsing/parsePackagesFromInstallArgs.spec.js
+++ b/src/packagemanager/npm/parsing/parsePackagesFromInstallArgs.spec.js
@@ -19,6 +19,14 @@ describe("parsePackagesFromInstallArgs", () => {
     assert.deepEqual(result, [{ name: "@jest/transform", version: "29.7.0" }]);
   });
 
+  it("should return the package in the format @vercel/otel", () => {
+    const args = ["install", "@vercel/otel"];
+
+    const result = parsePackagesFromInstallArgs(args);
+
+    assert.deepEqual(result, [{ name: "@vercel/otel", version: "latest" }]);
+  });
+
   it("should return an array of changes for multiple packages", () => {
     const args = ["install", "express@4.17.1", "lodash@4.17.21"];
 

--- a/src/packagemanager/npx/parsing/parsePackagesFromArguments.js
+++ b/src/packagemanager/npx/parsing/parsePackagesFromArguments.js
@@ -81,7 +81,9 @@ function parsePackagename(arg, defaultTag) {
   const lastAtIndex = arg.lastIndexOf("@");
 
   let name, version;
-  if (lastAtIndex !== -1) {
+  // The index of the last "@" should be greater than 0
+  // If the index is 0, it means the package name starts with "@" (eg: "@vercel/otel")
+  if (lastAtIndex > 0) {
     name = arg.slice(0, lastAtIndex);
     version = arg.slice(lastAtIndex + 1);
   } else {

--- a/src/packagemanager/npx/parsing/parsePackagesFromArguments.spec.js
+++ b/src/packagemanager/npx/parsing/parsePackagesFromArguments.spec.js
@@ -19,6 +19,14 @@ describe("parsePackagesFromArguments", () => {
     assert.deepEqual(result, [{ name: "http-server", version: "14.1.1" }]);
   });
 
+  it("should return the package in the format @vercel/otel", () => {
+    const args = ["@vercel/otel"];
+
+    const result = parsePackagesFromArguments(args);
+
+    assert.deepEqual(result, [{ name: "@vercel/otel", version: "latest" }]);
+  });
+
   it("should return the package with latest tag if absent", () => {
     const args = ["http-server"];
 

--- a/src/packagemanager/pnpm/parsing/parsePackagesFromArguments.spec.js
+++ b/src/packagemanager/pnpm/parsing/parsePackagesFromArguments.spec.js
@@ -27,6 +27,14 @@ describe("standardPnpmArgumentParser", () => {
     assert.deepEqual(result, [{ name: "axios", version: "latest" }]);
   });
 
+  it("should return the package in the format @vercel/otel", () => {
+    const args = ["@vercel/otel"];
+
+    const result = parsePackagesFromArguments(args);
+
+    assert.deepEqual(result, [{ name: "@vercel/otel", version: "latest" }]);
+  });
+
   it("should return the package with latest tag if the version is absent and package starts with @", () => {
     const args = ["@aikidosec/package-name"];
 

--- a/src/packagemanager/yarn/parsing/parsePackagesFromArguments.js
+++ b/src/packagemanager/yarn/parsing/parsePackagesFromArguments.js
@@ -77,7 +77,9 @@ function parsePackagename(arg, defaultTag) {
   const lastAtIndex = arg.lastIndexOf("@");
 
   let name, version;
-  if (lastAtIndex !== -1) {
+  // The index of the last "@" should be greater than 0
+  // If the index is 0, it means the package name starts with "@" (eg: "@vercel/otel")
+  if (lastAtIndex > 0) {
     name = arg.slice(0, lastAtIndex);
     version = arg.slice(lastAtIndex + 1);
   } else {

--- a/src/packagemanager/yarn/parsing/parsePackagesFromArguments.spec.js
+++ b/src/packagemanager/yarn/parsing/parsePackagesFromArguments.spec.js
@@ -38,6 +38,14 @@ describe("standardYarnArgumentParser", () => {
     ]);
   });
 
+  it("should return the package in the format @vercel/otel", () => {
+    const args = ["add", "@vercel/otel"];
+
+    const result = parsePackagesFromArguments(args);
+
+    assert.deepEqual(result, [{ name: "@vercel/otel", version: "latest" }]);
+  });
+
   it("should ignore options with parameters and return an array of changes", () => {
     const args = ["add", "--proxy", "http://localhost", "axios@1.9.0"];
 


### PR DESCRIPTION
Because the '@' in a scoped package (eg: `@vercel/otel`) was treated as the separator for the version number, the package was parsed as `name: ''`, `version: 'vercel/otel'`.

This led to the package with an empty string as name not being found on npm and ultimately resulting in an error being shown in the output.

Before:
<img width="1192" height="56" alt="image" src="https://github.com/user-attachments/assets/cc52218d-377f-4f40-9ed3-7f5aa6161d1f" />

After:
<img width="1185" height="41" alt="image" src="https://github.com/user-attachments/assets/5af92755-4ce4-4bb8-ad35-75e3b0125b45" />

