### PR TITLE
Default to exiting rather than allowing insecure behavior, fixes #24

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,12 @@ Installing the Aikido Safe Chain is easy. You just need 3 simple steps:
    ```
    - The output should show that Aikido Safe Chain is blocking the installation of this package as it is flagged as malware.
 
-When running `npm`, `npx`, `yarn`, `pnpm` or `pnpx` commands, the Aikido Safe Chain will automatically check for malware in the packages you are trying to install. If any malware is detected, it will prompt you to exit the command.
+When running `npm`, `npx`, `yarn`, `pnpm` or `pnpx` commands, the Aikido Safe Chain will automatically check for malware in the packages you are trying to install. If any malware is detected, the installation will be blocked by default for security.
+
+To override this safety check and install packages despite malware detection (not recommended), you can use:
+```shell
+INSTALL_A_POSSIBLY_MALICIOUS_PACKAGE=1 npm install <package-name>
+```
 
 ## How it works
 

--- a/packages/safe-chain/src/scanning/index.js
+++ b/packages/safe-chain/src/scanning/index.js
@@ -59,10 +59,7 @@ export async function scanCommand(args) {
     spinner.succeed("No malicious packages detected.");
   } else {
     printMaliciousChanges(audit.disallowedChanges, spinner);
-    await acceptRiskOrExit(
-      "Do you want to continue with the installation despite the risks?",
-      false
-    );
+    await acceptRiskOrExit();
   }
 }
 
@@ -74,19 +71,18 @@ function printMaliciousChanges(changes, spinner) {
   }
 }
 
-async function acceptRiskOrExit(message, defaultValue) {
-  ui.emptyLine();
-  const continueInstall = await ui.confirm({
-    message: message,
-    default: defaultValue,
-  });
-
-  if (continueInstall) {
-    ui.writeInformation("Continuing with the installation...");
+async function acceptRiskOrExit() {
+  // Check if the user has explicitly allowed risky installations
+  if (process.env.INSTALL_A_POSSIBLY_MALICIOUS_PACKAGE === "1") {
+    ui.emptyLine();
+    ui.writeInformation("INSTALL_A_POSSIBLY_MALICIOUS_PACKAGE=1 detected. Continuing with the installation despite risks...");
     return;
   }
 
-  ui.writeInformation("Exiting without installing packages.");
+  // Default secure behavior: exit without prompting
+  ui.emptyLine();
+  ui.writeInformation("Installation blocked due to malicious packages detected.");
+  ui.writeInformation("To override this safety check, run with: INSTALL_A_POSSIBLY_MALICIOUS_PACKAGE=1");
   ui.emptyLine();
   process.exit(1);
 }


### PR DESCRIPTION
This changes the default behavior when malicious packages are detected. We shouldn't be prompting users to continue – I think developers may be quite eager to just go ahead or accidentally press yes. Instead, immediately block installation with a non-zero exit code. 

Also, automated environments shouldn't have interactive prompts that could hang builds. Exiting with a nonzero code is the best default here.

An explicit override requires developers to _consciously_ set a (purposely named) clumsy environment variable to bypass checks.

Changes:

- Removes "Do you wish to continue..." prompt
- Exits immediately with code 1 when malicious packages detected
- Adds INSTALL_A_POSSIBLY_MALICIOUS_PACKAGE=1 environment variable for explicit overrides
- Updates documentation and tests

This should makes the package more secure by default while still allowing power users to override when absolutely necessary.

Disclosure: part of the code written by Claude Code with Sonnet 4, reviewed and tested:

```bash
$ cd packages/safe-chain && node --test --experimental-test-module-mocks src/**/*.spec.js
...
ℹ tests 140
ℹ suites 38
ℹ pass 140
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 1302.893542
```