### PR TITLE
Add coverage for pnpm i alias, fixes #36

### DIFF
--- a/packages/safe-chain/src/packagemanager/pnpm/createPackageManager.js
+++ b/packages/safe-chain/src/packagemanager/pnpm/createPackageManager.js
@@ -14,6 +14,7 @@ export function createPnpmPackageManager() {
       matchesCommand(args, "upgrade") ||
       matchesCommand(args, "up") ||
       matchesCommand(args, "install") ||
+      matchesCommand(args, "i") ||
       // dlx does not always come in the first position
       // eg: pnpm --package=yo --package=generator-webapp dlx yo webapp
       // documentation: https://pnpm.io/cli/dlx#--package-name


### PR DESCRIPTION
Coverage for `pnpm install` was added in #34, but the alias `i` was not covered. This adds coverage for the alias as well.