### PR TITLE
Rely on npm version rather than node version to determine which scanner to use. Fixes #46

### DIFF
--- a/packages/safe-chain/bin/aikido-npm.js
+++ b/packages/safe-chain/bin/aikido-npm.js
@@ -1,8 +1,19 @@
 #!/usr/bin/env node
 
+import { execSync } from "child_process";
 import { main } from "../src/main.js";
 import { initializePackageManager } from "../src/packagemanager/currentPackageManager.js";
 
 const packageManagerName = "npm";
-initializePackageManager(packageManagerName, process.versions.node);
+initializePackageManager(packageManagerName, getNpmVersion());
 await main(process.argv.slice(2));
+
+function getNpmVersion() {
+  try {
+    return execSync("npm --version").toString().trim();
+  } catch {
+    // Default to 0.0.0 if npm is not found
+    // That way we don't use any unsupported features
+    return "0.0.0";
+  }
+}

--- a/packages/safe-chain/src/packagemanager/npx/createPackageManager.js
+++ b/packages/safe-chain/src/packagemanager/npx/createPackageManager.js
@@ -5,7 +5,6 @@ export function createNpxPackageManager() {
   const scanner = commandArgumentScanner();
 
   return {
-    getWarningMessage: () => null,
     runCommand: runNpx,
     isSupportedCommand: (args) => scanner.shouldScan(args),
     getDependencyUpdatesForCommand: (args) => scanner.scan(args),

--- a/packages/safe-chain/src/packagemanager/pnpm/createPackageManager.js
+++ b/packages/safe-chain/src/packagemanager/pnpm/createPackageManager.js
@@ -6,7 +6,6 @@ const scanner = commandArgumentScanner();
 
 export function createPnpmPackageManager() {
   return {
-    getWarningMessage: () => null,
     runCommand: (args) => runPnpmCommand(args, "pnpm"),
     isSupportedCommand: (args) =>
       matchesCommand(args, "add") ||
@@ -26,7 +25,6 @@ export function createPnpmPackageManager() {
 
 export function createPnpxPackageManager() {
   return {
-    getWarningMessage: () => null,
     runCommand: (args) => runPnpmCommand(args, "pnpx"),
     isSupportedCommand: () => true,
     getDependencyUpdatesForCommand: (args) =>

--- a/packages/safe-chain/src/packagemanager/yarn/createPackageManager.js
+++ b/packages/safe-chain/src/packagemanager/yarn/createPackageManager.js
@@ -5,7 +5,6 @@ const scanner = commandArgumentScanner();
 
 export function createYarnPackageManager() {
   return {
-    getWarningMessage: () => null,
     runCommand: runYarnCommand,
     isSupportedCommand: (args) =>
       matchesCommand(args, "add") ||


### PR DESCRIPTION
Fixes #46