### PR TITLE
Respect HTTPS_PROXY when fetching malware database.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4877,6 +4877,7 @@
       "dependencies": {
         "abbrev": "^3.0.1",
         "chalk": "^5.4.1",
+        "make-fetch-happen": "^14.0.3",
         "npm-registry-fetch": "^18.0.2",
         "ora": "^8.2.0",
         "semver": "^7.7.2"
@@ -4895,7 +4896,8 @@
       "version": "1.0.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
-        "@aikidosec/safe-chain": "file:../safe-chain"
+        "@aikidosec/safe-chain": "file:../safe-chain",
+        "make-fetch-happen": "^14.0.3"
       },
       "peerDependencies": {
         "bun": ">=1.2.21"
@@ -4906,6 +4908,8 @@
       "version": "1.0.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
+        "@aikidosec/safe-chain": "file:../../packages/safe-chain",
+        "make-fetch-happen": "^14.0.3",
         "node-pty": "^1.0.0"
       }
     }

--- a/packages/safe-chain/package.json
+++ b/packages/safe-chain/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "abbrev": "^3.0.1",
     "chalk": "^5.4.1",
+    "make-fetch-happen": "^14.0.3",
     "npm-registry-fetch": "^18.0.2",
     "ora": "^8.2.0",
     "semver": "^7.7.2"

--- a/packages/safe-chain/src/api/aikido.js
+++ b/packages/safe-chain/src/api/aikido.js
@@ -1,3 +1,5 @@
+import fetch from "make-fetch-happen";
+
 const malwareDatabaseUrl =
   "https://malware-list.aikido.dev/malware_predictions.json";
 


### PR DESCRIPTION
Fixes #41

Rather than implementing the proxy configuration ourselves, this PR introduces make-fetch-happen instead. This package was already imported as a dependency of npm-registry-fetch as a transitive dependency, now it is a direct dependency.