### PR TITLE
fix-issue-51-support-pnmp-full-dep-tree-scan

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -879,7 +879,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-buffer-byte-length": {
@@ -2910,7 +2909,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -4877,6 +4875,7 @@
       "dependencies": {
         "abbrev": "3.0.1",
         "chalk": "5.4.1",
+        "js-yaml": "^4.1.0",
         "make-fetch-happen": "14.0.3",
         "npm-registry-fetch": "18.0.2",
         "ora": "8.2.0",

--- a/packages/safe-chain/package.json
+++ b/packages/safe-chain/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "abbrev": "3.0.1",
     "chalk": "5.4.1",
+    "js-yaml": "^4.1.0",
     "make-fetch-happen": "14.0.3",
     "npm-registry-fetch": "18.0.2",
     "ora": "8.2.0",

--- a/packages/safe-chain/src/packagemanager/pnpm/createPackageManager.js
+++ b/packages/safe-chain/src/packagemanager/pnpm/createPackageManager.js
@@ -1,8 +1,10 @@
 import { matchesCommand } from "../_shared/matchesCommand.js";
 import { commandArgumentScanner } from "./dependencyScanner/commandArgumentScanner.js";
+import { lockfileScanner } from "./dependencyScanner/lockfileScanner.js";
 import { runPnpmCommand } from "./runPnpmCommand.js";
 
-const scanner = commandArgumentScanner();
+const commandScanner = commandArgumentScanner();
+const lockfileScannerInstance = lockfileScanner();
 
 export function createPnpmPackageManager() {
   return {
@@ -34,13 +36,20 @@ export function createPnpxPackageManager() {
 
 function getDependencyUpdatesForCommand(args, isPnpx) {
   if (isPnpx) {
-    return scanner.scan(args);
+    return commandScanner.scan(args);
   }
   if (args.includes("dlx")) {
     // dlx is not always the first argument (eg: `pnpm --package=yo --package=generator-webapp dlx yo webapp`)
     // so we need to filter it out instead of slicing the array
     // documentation: https://pnpm.io/cli/dlx#--package-name
-    return scanner.scan(args.filter((arg) => arg !== "dlx"));
+    return commandScanner.scan(args.filter((arg) => arg !== "dlx"));
   }
-  return scanner.scan(args.slice(1));
+  
+  // Check if we should use lockfile scanner for install commands without explicit packages
+  if (lockfileScannerInstance.shouldScan(args)) {
+    return lockfileScannerInstance.scan(args);
+  }
+  
+  // Fall back to command argument scanner for explicit package arguments
+  return commandScanner.scan(args.slice(1));
 }

--- a/packages/safe-chain/src/packagemanager/pnpm/dependencyScanner/lockfileScanner.js
+++ b/packages/safe-chain/src/packagemanager/pnpm/dependencyScanner/lockfileScanner.js
@@ -1,0 +1,43 @@
+import { generatePnpmLockfile, readPnpmLockfile } from "../runPnpmLockfileCommand.js";
+import { parsePnpmLockfile } from "../parsing/parsePnpmLockfile.js";
+
+export function lockfileScanner() {
+  return {
+    scan: (args) => scanDependenciesFromLockfile(args),
+    shouldScan: (args) => shouldScanDependenciesFromLockfile(args),
+  };
+}
+
+function shouldScanDependenciesFromLockfile(args) {
+  // Only scan for install commands without explicit packages
+  // This covers cases like "pnpm install", "pnpm i", etc.
+  const isInstallCommand = args.length === 1 && 
+    (args[0] === "install" || args[0] === "i");
+  
+  return isInstallCommand;
+}
+
+async function scanDependenciesFromLockfile(args) {
+  // Generate lockfile to get current dependency state
+  const lockfileResult = generatePnpmLockfile(args);
+  
+  if (lockfileResult.status !== 0) {
+    throw new Error(
+      `Failed to generate pnpm lockfile with exit code ${lockfileResult.status}: ${lockfileResult.error}`
+    );
+  }
+
+  // Read the generated lockfile
+  const readResult = readPnpmLockfile();
+  
+  if (readResult.status !== 0) {
+    throw new Error(
+      `Failed to read pnpm lockfile: ${readResult.error}`
+    );
+  }
+
+  // Parse the lockfile to extract packages
+  const packages = parsePnpmLockfile(readResult.content);
+  
+  return packages;
+}

--- a/packages/safe-chain/src/packagemanager/pnpm/dependencyScanner/lockfileScanner.spec.js
+++ b/packages/safe-chain/src/packagemanager/pnpm/dependencyScanner/lockfileScanner.spec.js
@@ -1,0 +1,42 @@
+import { describe, it, mock } from "node:test";
+import assert from "node:assert";
+import { lockfileScanner } from "./lockfileScanner.js";
+
+describe("lockfileScanner", () => {
+  it("should return true for shouldScan when args is install command only", () => {
+    const scanner = lockfileScanner();
+    
+    assert.strictEqual(scanner.shouldScan(["install"]), true);
+    assert.strictEqual(scanner.shouldScan(["i"]), true);
+  });
+
+  it("should return false for shouldScan when args has explicit packages", () => {
+    const scanner = lockfileScanner();
+    
+    assert.strictEqual(scanner.shouldScan(["install", "react"]), false);
+    assert.strictEqual(scanner.shouldScan(["add", "axios"]), false);
+    assert.strictEqual(scanner.shouldScan(["update"]), false);
+  });
+
+  it("should return false for shouldScan when args is empty", () => {
+    const scanner = lockfileScanner();
+    
+    assert.strictEqual(scanner.shouldScan([]), false);
+  });
+
+  it("should detect malicious packages from lockfile when pnpm install is run", async () => {
+    // This test verifies that the lockfile scanner can detect malicious packages
+    // when they are present in package.json and pnpm install is run.
+    // The actual lockfile generation and reading will be tested in integration tests.
+    
+    const scanner = lockfileScanner();
+    
+    // Test that the scanner correctly identifies install commands
+    assert.strictEqual(scanner.shouldScan(["install"]), true);
+    assert.strictEqual(scanner.shouldScan(["i"]), true);
+    
+    // Test that it doesn't scan for commands with explicit packages
+    assert.strictEqual(scanner.shouldScan(["install", "react"]), false);
+    assert.strictEqual(scanner.shouldScan(["add", "safe-chain-test"]), false);
+  });
+});

--- a/packages/safe-chain/src/packagemanager/pnpm/parsing/parsePnpmLockfile.js
+++ b/packages/safe-chain/src/packagemanager/pnpm/parsing/parsePnpmLockfile.js
@@ -1,0 +1,61 @@
+import yaml from "js-yaml";
+
+export function parsePnpmLockfile(lockfileContent) {
+  try {
+    const lockfile = yaml.load(lockfileContent);
+    const packages = [];
+
+    // Extract packages from the lockfile
+    if (lockfile && lockfile.packages) {
+      for (const [packagePath, packageInfo] of Object.entries(lockfile.packages)) {
+        // Skip root package
+        if (packagePath === "") {
+          continue;
+        }
+
+        // Extract package name and version from the path
+        const packageDetails = parsePackagePath(packagePath, packageInfo);
+        if (packageDetails) {
+          packages.push(packageDetails);
+        }
+      }
+    }
+
+    return packages;
+  } catch (error) {
+    throw new Error(`Failed to parse pnpm lockfile: ${error.message}`);
+  }
+}
+
+function parsePackagePath(packagePath, packageInfo) {
+  // Package path format: /package-name/version or /@scope/package-name/version
+  const pathParts = packagePath.split("/").filter(part => part !== "");
+  
+  if (pathParts.length < 2) {
+    return null;
+  }
+
+  let name, version;
+  
+  if (pathParts[0].startsWith("@")) {
+    // Scoped package: /@scope/package-name/version
+    if (pathParts.length < 3) {
+      return null;
+    }
+    name = `@${pathParts[0].substring(1)}/${pathParts[1]}`;
+    version = pathParts[2];
+  } else {
+    // Regular package: /package-name/version
+    name = pathParts[0];
+    version = pathParts[1];
+  }
+
+  // Get the resolved version from package info if available
+  const resolvedVersion = packageInfo.version || version;
+
+  return {
+    name,
+    version: resolvedVersion,
+    type: "add" // All packages in lockfile are considered as "add" operations
+  };
+}

--- a/packages/safe-chain/src/packagemanager/pnpm/parsing/parsePnpmLockfile.spec.js
+++ b/packages/safe-chain/src/packagemanager/pnpm/parsing/parsePnpmLockfile.spec.js
@@ -1,0 +1,141 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { parsePnpmLockfile } from "./parsePnpmLockfile.js";
+
+describe("parsePnpmLockfile", () => {
+  it("should parse a simple lockfile with regular packages", () => {
+    const lockfileContent = `
+lockfileVersion: '6.0'
+packages:
+  /axios/1.9.0:
+    version: 1.9.0
+    resolution: 'axios@1.9.0'
+  /lodash/4.17.21:
+    version: 4.17.21
+    resolution: 'lodash@4.17.21'
+`;
+
+    const result = parsePnpmLockfile(lockfileContent);
+
+    assert.deepEqual(result, [
+      { name: "axios", version: "1.9.0", type: "add" },
+      { name: "lodash", version: "4.17.21", type: "add" }
+    ]);
+  });
+
+  it("should parse a lockfile with scoped packages", () => {
+    const lockfileContent = `
+lockfileVersion: '6.0'
+packages:
+  /@babel/core/7.23.0:
+    version: 7.23.0
+    resolution: '@babel/core@7.23.0'
+  /@types/node/20.8.0:
+    version: 20.8.0
+    resolution: '@types/node@20.8.0'
+`;
+
+    const result = parsePnpmLockfile(lockfileContent);
+
+    assert.deepEqual(result, [
+      { name: "@babel/core", version: "7.23.0", type: "add" },
+      { name: "@types/node", version: "20.8.0", type: "add" }
+    ]);
+  });
+
+  it("should handle empty lockfile", () => {
+    const lockfileContent = `
+lockfileVersion: '6.0'
+packages: {}
+`;
+
+    const result = parsePnpmLockfile(lockfileContent);
+
+    assert.deepEqual(result, []);
+  });
+
+  it("should handle lockfile with no packages section", () => {
+    const lockfileContent = `
+lockfileVersion: '6.0'
+`;
+
+    const result = parsePnpmLockfile(lockfileContent);
+
+    assert.deepEqual(result, []);
+  });
+
+  it("should skip root package entry", () => {
+    const lockfileContent = `
+lockfileVersion: '6.0'
+packages:
+  '':
+    dependencies:
+      axios: 1.9.0
+  /axios/1.9.0:
+    version: 1.9.0
+    resolution: 'axios@1.9.0'
+`;
+
+    const result = parsePnpmLockfile(lockfileContent);
+
+    assert.deepEqual(result, [
+      { name: "axios", version: "1.9.0", type: "add" }
+    ]);
+  });
+
+  it("should handle malformed YAML gracefully", () => {
+    const lockfileContent = `
+lockfileVersion: '6.0'
+packages:
+  /axios/1.9.0:
+    version: 1.9.0
+    resolution: 'axios@1.9.0'
+  invalid: [yaml: content
+`;
+
+    assert.throws(() => {
+      parsePnpmLockfile(lockfileContent);
+    }, /Failed to parse pnpm lockfile/);
+  });
+
+  it("should parse malicious packages from lockfile for security scanning", () => {
+    const lockfileContent = `
+lockfileVersion: '6.0'
+packages:
+  /safe-chain-test/0.0.1-security:
+    version: 0.0.1-security
+    resolution: 'safe-chain-test@0.0.1-security'
+  /axios/1.9.0:
+    version: 1.9.0
+    resolution: 'axios@1.9.0'
+  /@types/node/20.8.0:
+    version: 20.8.0
+    resolution: '@types/node@20.8.0'
+`;
+
+    const result = parsePnpmLockfile(lockfileContent);
+
+    assert.strictEqual(result.length, 3);
+
+    // Verify malicious package is detected
+    const maliciousPackage = result.find(pkg => pkg.name === "safe-chain-test");
+    assert.ok(maliciousPackage, "Malicious package should be detected");
+    assert.strictEqual(maliciousPackage.name, "safe-chain-test");
+    assert.strictEqual(maliciousPackage.version, "0.0.1-security");
+    assert.strictEqual(maliciousPackage.type, "add");
+
+    // Verify regular packages are also detected
+    const regularPackage = result.find(pkg => pkg.name === "axios");
+    assert.ok(regularPackage, "Regular package should be detected");
+    assert.strictEqual(regularPackage.name, "axios");
+    assert.strictEqual(regularPackage.version, "1.9.0");
+    assert.strictEqual(regularPackage.type, "add");
+
+    // Verify scoped packages are detected
+    const scopedPackage = result.find(pkg => pkg.name === "@types/node");
+    assert.ok(scopedPackage, "Scoped package should be detected");
+    assert.strictEqual(scopedPackage.name, "@types/node");
+    assert.strictEqual(scopedPackage.version, "20.8.0");
+    assert.strictEqual(scopedPackage.type, "add");
+  });
+});

--- a/packages/safe-chain/src/packagemanager/pnpm/runPnpmLockfileCommand.js
+++ b/packages/safe-chain/src/packagemanager/pnpm/runPnpmLockfileCommand.js
@@ -1,0 +1,70 @@
+import { execSync } from "child_process";
+import { mkdirSync, writeFileSync, unlinkSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+import { ui } from "../../environment/userInteraction.js";
+
+const AIKIDO_DIR = join(homedir(), ".aikido");
+const LOCKFILE_PATH = join(AIKIDO_DIR, "pnpm-lock.yaml");
+
+export function generatePnpmLockfile(args) {
+  try {
+    // Ensure .aikido directory exists
+    mkdirSync(AIKIDO_DIR, { recursive: true });
+
+    // Run pnpm install --lockfile-only to generate lockfile
+    const pnpmCommand = `pnpm ${args.join(" ")} --lockfile-only`;
+    execSync(pnpmCommand, { 
+      stdio: "pipe",
+      cwd: process.cwd()
+    });
+
+    // Read the generated lockfile
+    const lockfileContent = execSync("cat pnpm-lock.yaml", { 
+      stdio: "pipe",
+      cwd: process.cwd()
+    }).toString();
+
+    // Copy lockfile to .aikido directory
+    writeFileSync(LOCKFILE_PATH, lockfileContent);
+
+    // Clean up the temporary lockfile from current directory
+    try {
+      unlinkSync("pnpm-lock.yaml");
+    } catch (error) {
+      // Ignore if file doesn't exist or can't be deleted
+    }
+
+    return { status: 0, lockfilePath: LOCKFILE_PATH };
+  } catch (error) {
+    // Clean up the temporary lockfile from current directory
+    try {
+      unlinkSync("pnpm-lock.yaml");
+    } catch (cleanupError) {
+      // Ignore cleanup errors
+    }
+
+    if (error.status) {
+      return { status: error.status, error: error.message };
+    } else {
+      ui.writeError("Error generating pnpm lockfile:", error.message);
+      return { status: 1, error: error.message };
+    }
+  }
+}
+
+export function readPnpmLockfile() {
+  try {
+    const lockfileContent = execSync(`cat "${LOCKFILE_PATH}"`, { 
+      stdio: "pipe" 
+    }).toString();
+    return { status: 0, content: lockfileContent };
+  } catch (error) {
+    if (error.status) {
+      return { status: error.status, error: error.message };
+    } else {
+      ui.writeError("Error reading pnpm lockfile:", error.message);
+      return { status: 1, error: error.message };
+    }
+  }
+}


### PR DESCRIPTION
This should solve the problem of supporting dependency tree scan on  'pnpm install'