### PR TITLE
Listen to error events on sockets

### DIFF
--- a/packages/safe-chain/src/registryProxy/mitmRequestHandler.js
+++ b/packages/safe-chain/src/registryProxy/mitmRequestHandler.js
@@ -5,6 +5,12 @@ import { HttpsProxyAgent } from "https-proxy-agent";
 export function mitmConnect(req, clientSocket, isAllowed) {
   const { hostname } = new URL(`http://${req.url}`);
 
+  clientSocket.on("error", () => {
+    // NO-OP
+    // This can happen if the client TCP socket sends RST instead of FIN.
+    // Not subscribing to 'close' event will cause node to throw and crash.
+  });
+
   const server = createHttpsServer(hostname, isAllowed);
 
   // Establish the connection

--- a/packages/safe-chain/src/registryProxy/tunnelRequestHandler.js
+++ b/packages/safe-chain/src/registryProxy/tunnelRequestHandler.js
@@ -24,6 +24,12 @@ export function tunnelRequest(req, clientSocket, head) {
 function tunnelRequestToDestination(req, clientSocket, head) {
   const { port, hostname } = new URL(`http://${req.url}`);
 
+  clientSocket.on("error", () => {
+    // NO-OP
+    // This can happen if the client TCP socket sends RST instead of FIN.
+    // Not subscribing to 'close' event will cause node to throw and crash.
+  });
+
   const serverSocket = net.connect(port || 443, hostname, () => {
     clientSocket.write("HTTP/1.1 200 Connection Established\r\n\r\n");
     serverSocket.write(head);


### PR DESCRIPTION
When no listener has been added to the error event on a socket, it will cause node to throw and exit out of the process.

In this case, an error like this is shown in the output of the process:
Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20)
Emitted 'error' event on Socket instance at:
    at Socket.onerror (node:internal/streams/readable:1028:14)
    at Socket.emit (node:events:519:28)
    at emitErrorNT (node:internal/streams/destroy:170:8)
    at emitErrorCloseNT (node:internal/streams/destroy:129:3)
    at process.processTicksAndRejections (node:internal/process/task_queues:90:21) {
  errno: -4077,
  code: 'ECONNRESET',
  syscall: 'read'
}