### PR TITLE
test(e2e): capture docker build output instead of ignoring it

### DIFF
--- a/test/e2e/DockerTestContainer.js
+++ b/test/e2e/DockerTestContainer.js
@@ -36,7 +36,7 @@ export class DockerTestContainer {
         `docker build --progress=plain -t ${imageName} -f ${dockerFile} ${contextPath} ${buildArgs}`,
         {
           stdio: "pipe",
-          maxBuffer: 50 * 1024 * 1024, // 50MB buffer to capture verbose build logs
+          maxBuffer: 10 * 1024 * 1024, // Default is 1MB, increase to 10MB to account for large build logs
         }
       );
     } catch (error) {

--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -41,11 +41,11 @@ RUN apt-get install -y fish && \
     touch /root/.config/fish/config.fish
 
 # Install Volta and Node.js
-RUN curl -sSL https://get.volta.sh | bash
-RUN /root/.volta/bin/volta install node@${NODE_VERSION}
-RUN /root/.volta/bin/volta install npm@${NPM_VERSION}
-RUN /root/.volta/bin/volta install yarn@${YARN_VERSION}
-RUN /root/.volta/bin/volta install pnpm@${PNPM_VERSION}
+RUN curl -fsSL https://get.volta.sh | bash
+RUN volta install node@${NODE_VERSION}
+RUN volta install npm@${NPM_VERSION}
+RUN volta install yarn@${YARN_VERSION}
+RUN volta install pnpm@${PNPM_VERSION}
 
 # Install Bun
 RUN curl -fsSL https://bun.sh/install | bash


### PR DESCRIPTION
This will also prevent stdio "EIO" errors in certain conditions where Docker is closing the pipe before writing buffer is complete