### PR TITLE
Fix build: install packages before setting the version

### DIFF
--- a/.github/workflows/create-artifact.yml
+++ b/.github/workflows/create-artifact.yml
@@ -5,7 +5,7 @@ on:
   workflow_call:
     inputs:
       version:
-        description: 'Version to set in package.json'
+        description: "Version to set in package.json"
         required: false
         type: string
 
@@ -64,12 +64,12 @@ jobs:
           npm i -g @aikidosec/safe-chain
           safe-chain setup-ci
 
-      - name: Set the version in safe-chain package
-        if: inputs.version != ''
-        run: npm --no-git-tag-version version ${{ inputs.version }} --workspace=packages/safe-chain
-
       - name: Install dependencies
         run: npm ci --ignore-scripts
+
+      - name: Set the version in safe-chain package
+        if: inputs.version != ''
+        run: npm --no-git-tag-version version ${{ inputs.version }} --workspace=packages/safe-chain --ignore-scripts
 
       - name: Create binary
         run: |


### PR DESCRIPTION
Build was breaking on windows because of post-install scripts from `node-gyp`