### PR TITLE
fix: use true connection timeout instead of idle timeout

### DIFF
--- a/packages/safe-chain/src/registryProxy/registryProxy.connect-tunnel.spec.js
+++ b/packages/safe-chain/src/registryProxy/registryProxy.connect-tunnel.spec.js
@@ -182,13 +182,13 @@ describe("registryProxy.connectTunnel", () => {
 
       const duration = Date.now() - startTime;
 
-      // Should return 502 Bad Gateway
+      // Should return 504 Gateway Timeout (not 502 - 504 is for actual timeouts)
       assert.ok(
-        responseData.includes("HTTP/1.1 502 Bad Gateway"),
-        "Should return 502 for timeout"
+        responseData.includes("HTTP/1.1 504 Gateway Timeout"),
+        "Should return 504 for timeout"
       );
 
-      // Should timeout around 3 seconds for IMDS endpoints (allow some margin)
+      // Should timeout around 100ms for IMDS endpoints (allow some margin)
       assert.ok(
         duration >= 80 && duration < 200,
         `IMDS timeout should be ~80-200ms, got ${duration}ms`
@@ -280,10 +280,10 @@ describe("registryProxy.connectTunnel", () => {
 
       const duration = Date.now() - startTime;
 
-      // Should return 502 Bad Gateway (timeout)
+      // Should return 504 Gateway Timeout (not 502 - 504 is for actual timeouts)
       assert.ok(
-        responseData.includes("HTTP/1.1 502 Bad Gateway"),
-        "Should return 502 for timeout"
+        responseData.includes("HTTP/1.1 504 Gateway Timeout"),
+        "Should return 504 for timeout"
       );
 
       // Should NOT be instant - it should retry the connection (taking ~500ms due to mock timeout)


### PR DESCRIPTION
## Summary

- Replace `socket.setTimeout()` (idle timeout) with JS `setTimeout()` (true connection timeout)
- Timer gets cleared on successful connect, preventing false timeout errors
- Change timeout response from 502 to 504 (more semantically correct)
- Add proper `close` event handlers for socket cleanup

## Problem

`socket.setTimeout()` in Node.js is an **idle timeout** (node docs)[https://nodejs.org/api/net.html#socketsettimeouttimeout-callback] - it fires after N ms of inactivity, not N ms after the connection attempt. This caused false timeout errors after successful data transfers when connections went idle for longer than the timeout period.

Most other languages (Python, Java, Go, C) treat socket timeout as an operation timeout, not idle timeout. This makes Node.js behavior surprising.

## Solution

Use JS `setTimeout()` which:
- Fires N ms after connection attempt starts (true connection timeout)
- Gets cleared immediately on successful connect
- Never fires after successful data transfer

## Test plan

- [x] All existing tunnel tests pass
- [x] Updated test expectations for 504 response code
- [x] Tested timeout behavior with IMDS and non-IMDS endpoints

Fixes #228

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido Security
**⚡ Enhancements**
* Cleared connect timer on success and added socket close handlers
* Changed timeout response from 502 to 504 for semantic accuracy

**🐛 Bugfixes**
* Replaced socket idle timeout with JS timer to fix false timeouts
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->