### PR TITLE
Fix proxy request to respect HTTPS port from CONNECT request

### DIFF
--- a/packages/safe-chain/src/registryProxy/mitmRequestHandler.js
+++ b/packages/safe-chain/src/registryProxy/mitmRequestHandler.js
@@ -166,7 +166,7 @@ function createProxyRequest(hostname, port, req, res, requestHandler) {
   /** @type {import("http").RequestOptions} */
   const options = {
     hostname: hostname,
-    port: port,
+    port: port || 443,
     path: req.url,
     method: req.method,
     headers: { ...headers },


### PR DESCRIPTION
Currently the proxy request is hardcoded to use port 443 causing custom registries on non-default ports (e.g., 8443) to fail. This change gets the port from the CONNECT request URL and uses it when forwarding requests, while keeping 443 as the default if no port is supplied. Tries to fix #263 