### PR TITLE
fix: Allow running commands if safe-chain npm package is not installed

### DIFF
--- a/packages/safe-chain/src/shell-integration/startup-scripts/init-posix.sh
+++ b/packages/safe-chain/src/shell-integration/startup-scripts/init-posix.sh
@@ -83,10 +83,6 @@ function wrapSafeChainCommand() {
     # If the aikido command is not available, print a warning and run the original command
     printSafeChainWarning "$original_cmd"
 
-    # Remove the first argument (original_cmd) from $@
-    # so that "$@" now contains only the arguments passed to the original command
-    shift 1
-
-    command "$original_cmd" "$@"
+    command "$@"
   fi
 }


### PR DESCRIPTION
If safe-chain npm package is not available (common when using multiple node versions via nvm etc), the original command does not run correctly as it is passed it's command name as the first argument. So `npm install -g @aikidosec/safe-chain` actually gets run as `npm npm install -g @aikidosec/safe-chain` which fails. 
The previous version of this script (prior to #185) removed the additional argument, but it looks like this was accidentally dropped in the refactor.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Fixed incorrect command invocation when safe-chain was not installed


<sup>[More info](https://app.aikido.dev/featurebranch/scan/71059122?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->