### PR TITLE
Fix double dash argument forwarding on Win32 PowerShell

### DIFF
--- a/packages/safe-chain/src/shell-integration/startup-scripts/init-pwsh.ps1
+++ b/packages/safe-chain/src/shell-integration/startup-scripts/init-pwsh.ps1
@@ -155,7 +155,6 @@ function Invoke-WrappedCommand {
         $reconstructedArgs = Get-ReconstructedArguments $RawLine $RawOffset
         if ($null -ne $reconstructedArgs) {
             $Arguments = $reconstructedArgs
-            Write-Host "Safe-chain Powershell Wrapper: Reconstructed args: $($Arguments -join ' ')" 
         }
     }
 


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 2 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Forwarded raw invocation line and offset into wrapper functions.
* Preferred executing safe-chain.cmd on Windows when it was available.

**🐛 Bugfixes**
* Reconstructed original command-line arguments to preserve '--' on Windows.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/74162472?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->