### PR TITLE
Include package name in logging when minimum package age is not met

### DIFF
--- a/packages/safe-chain/src/registryProxy/interceptors/npm/modifyNpmInfo.js
+++ b/packages/safe-chain/src/registryProxy/interceptors/npm/modifyNpmInfo.js
@@ -118,7 +118,7 @@ function deleteVersionFromJson(json, version) {
 
   const packageName = typeof json?.name === "string" ? json.name : "(unknown)";
 
-  ui.writeInformation(
+  ui.writeVerbose(
     `Safe-chain: ${packageName}@${version} is newer than ${getMinimumPackageAgeHours()} hours and was removed (minimumPackageAgeInHours setting).`
   );
 


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Included package name in verbose logging when suppressing new versions.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/74416758?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->