### PR TITLE
Use bash for setting up safe-chain in CI

### DIFF
--- a/.github/workflows/create-artifact.yml
+++ b/.github/workflows/create-artifact.yml
@@ -70,7 +70,7 @@ jobs:
           node-version: "20.x"
 
       - name: Setup safe-chain
-        run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/download/0.0.1-windows-install-script-in-git-bash-beta/install-safe-chain.sh | sh -s -- --ci
+        run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
         shell: bash
 
       - name: Install dependencies

--- a/.github/workflows/test-on-pr.yml
+++ b/.github/workflows/test-on-pr.yml
@@ -23,7 +23,7 @@ jobs:
           node-version: "lts/*"
 
       - name: Setup safe-chain
-        run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/download/0.0.1-windows-install-script-in-git-bash-beta/install-safe-chain.sh | sh -s -- --ci
+        run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
         shell: bash
 
       - name: Install dependencies


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Replaced platform-specific safe-chain setup with unified bash installer
* Updated CI actions and checkout versions in E2E workflow


<sup>[More info](https://app.aikido.dev/featurebranch/scan/88724608?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->