### PR TITLE
Don't insert empty line in rc file when it already ends with an empty line.

### DIFF
--- a/packages/safe-chain/src/shell-integration/helpers.js
+++ b/packages/safe-chain/src/shell-integration/helpers.js
@@ -99,7 +99,7 @@ export const knownAikidoTools = [
     aikidoCommand: "aikido-pipx",
     ecoSystem: ECOSYSTEM_PY,
     internalPackageManagerName: "pipx",
-  }
+  },
   // When adding a new tool here, also update the documentation for the new tool in the README.md
 ];
 
@@ -216,7 +216,13 @@ export function addLineToFile(filePath, line, eol) {
   eol = eol || os.EOL;
 
   const fileContent = fs.readFileSync(filePath, "utf-8");
-  const updatedContent = fileContent + eol + line + eol;
+  let updatedContent = fileContent;
+
+  if (!fileContent.endsWith(eol)) {
+    updatedContent += eol;
+  }
+
+  updatedContent += line + eol;
   fs.writeFileSync(filePath, updatedContent, "utf-8");
 }
 


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Prevented inserting an extra blank line when file already ended

**🔧 Refactors**
* Adjusted object trailing comma formatting in knownAikidoTools array


<sup>[More info](https://app.aikido.dev/featurebranch/scan/78158563?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->