### PR TITLE
[Python Improvements]: Add uvx support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Aikido Safe Chain supports the following package managers:
 - 📦 **pip3**
 - 📦 **uv**
 - 📦 **poetry**
+- 📦 **uvx**
 - 📦 **pipx**
 
 # Usage
@@ -66,7 +67,7 @@ You can find all available versions on the [releases page](https://github.com/Ai
 ### Verify the installation
 
 1. **❗Restart your terminal** to start using the Aikido Safe Chain.
-   - This step is crucial as it ensures that the shell aliases for npm, npx, yarn, pnpm, pnpx, bun, bunx, pip, pip3, poetry, uv and pipx are loaded correctly. If you do not restart your terminal, the aliases will not be available.
+   - This step is crucial as it ensures that the shell aliases for npm, npx, yarn, pnpm, pnpx, bun, bunx, pip, pip3, poetry, uv, uvx and pipx are loaded correctly. If you do not restart your terminal, the aliases will not be available.
 
 2. **Verify the installation** by running the verification command:
 
@@ -97,7 +98,7 @@ You can find all available versions on the [releases page](https://github.com/Ai
 
    - The output should show that Aikido Safe Chain is blocking the installation of these test packages as they are flagged as malware.
 
-When running `npm`, `npx`, `yarn`, `pnpm`, `pnpx`, `bun`, `bunx`, `pip`, `pip3`, `uv`, `poetry` and `pipx` commands, the Aikido Safe Chain will automatically check for malware in the packages you are trying to install. It also intercepts Python module invocations for pip when available (e.g., `python -m pip install ...`, `python3 -m pip download ...`). If any malware is detected, it will prompt you to exit the command.
+When running `npm`, `npx`, `yarn`, `pnpm`, `pnpx`, `bun`, `bunx`, `pip`, `pip3`, `uv`, `uvx`, `poetry` and `pipx` commands, the Aikido Safe Chain will automatically check for malware in the packages you are trying to install. It also intercepts Python module invocations for pip when available (e.g., `python -m pip install ...`, `python3 -m pip download ...`). If any malware is detected, it will prompt you to exit the command.
 
 You can check the installed version by running:
 
@@ -109,7 +110,7 @@ safe-chain --version
 
 ### Malware Blocking
 
-The Aikido Safe Chain works by running a lightweight proxy server that intercepts package downloads from the npm registry and PyPI. When you run npm, npx, yarn, pnpm, pnpx, bun, bunx, pip, pip3, uv, poetry or pipx commands, all package downloads are routed through this local proxy, which verifies packages in real-time against **[Aikido Intel - Open Sources Threat Intelligence](https://intel.aikido.dev/?tab=malware)**. If malware is detected in any package (including deep dependencies), the proxy blocks the download before the malicious code reaches your machine.
+The Aikido Safe Chain works by running a lightweight proxy server that intercepts package downloads from the npm registry and PyPI. When you run npm, npx, yarn, pnpm, pnpx, bun, bunx, pip, pip3, uv, uvx, poetry or pipx commands, all package downloads are routed through this local proxy, which verifies packages in real-time against **[Aikido Intel - Open Sources Threat Intelligence](https://intel.aikido.dev/?tab=malware)**. If malware is detected in any package (including deep dependencies), the proxy blocks the download before the malicious code reaches your machine.
 
 ### Minimum package age
 
@@ -128,7 +129,7 @@ By default, the minimum package age is 48 hours. This provides an additional sec
 
 ### Shell Integration
 
-The Aikido Safe Chain integrates with your shell to provide a seamless experience when using npm, npx, yarn, pnpm, pnpx, bun, bunx, and Python package managers (pip, uv, poetry, pipx). It sets up aliases for these commands so that they are wrapped by the Aikido Safe Chain commands, which manage the proxy server before executing the original commands. We currently support:
+The Aikido Safe Chain integrates with your shell to provide a seamless experience when using npm, npx, yarn, pnpm, pnpx, bun, bunx, and Python package managers (pip, uv, uvx, poetry, pipx). It sets up aliases for these commands so that they are wrapped by the Aikido Safe Chain commands, which manage the proxy server before executing the original commands. We currently support:
 
 - ✅ **Bash**
 - ✅ **Zsh**

--- a/docs/shell-integration.md
+++ b/docs/shell-integration.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The shell integration automatically wraps common package manager commands (`npm`, `npx`, `yarn`, `pnpm`, `pnpx`, `bun`, `bunx`, `pip`, `pip3`, `uv`, `poetry`, `pipx`) with Aikido's security scanning functionality. It also intercepts Python module invocations for pip when available: `python -m pip`, `python -m pip3`, `python3 -m pip`, `python3 -m pip3`. This is achieved by sourcing startup scripts that define shell functions to wrap these commands with their Aikido-protected equivalents.
+The shell integration automatically wraps common package manager commands (`npm`, `npx`, `yarn`, `pnpm`, `pnpx`, `bun`, `bunx`, `pip`, `pip3`, `uv`, `uvx`, `poetry`, `pipx`) with Aikido's security scanning functionality. It also intercepts Python module invocations for pip when available: `python -m pip`, `python -m pip3`, `python3 -m pip`, `python3 -m pip3`. This is achieved by sourcing startup scripts that define shell functions to wrap these commands with their Aikido-protected equivalents.
 
 ## Supported Shells
 
@@ -28,7 +28,7 @@ This command:
 
 - Copies necessary startup scripts to Safe Chain's installation directory (`~/.safe-chain/scripts`)
 - Detects all supported shells on your system
-- Sources each shell's startup file to add Safe Chain functions for `npm`, `npx`, `yarn`, `pnpm`, `pnpx`, `bun`, `bunx`, `pip`, `pip3`, `uv`, `poetry` and `pipx`
+- Sources each shell's startup file to add Safe Chain functions for `npm`, `npx`, `yarn`, `pnpm`, `pnpx`, `bun`, `bunx`, `pip`, `pip3`, `uv`, `uvx`, `poetry` and `pipx`
 - Adds lightweight interceptors so `python -m pip[...]` and `python3 -m pip[...]` route through Safe Chain when invoked by name
 
 ❗ After running this command, **you must restart your terminal** for the changes to take effect. This ensures that the startup scripts are sourced correctly.
@@ -78,7 +78,7 @@ The system modifies the following files to source Safe Chain startup scripts:
 This means the shell functions are working but the Aikido commands aren't installed or available in your PATH:
 
 - Make sure Aikido Safe Chain is properly installed on your system
-- Verify the `aikido-npm`, `aikido-npx`, `aikido-yarn`, `aikido-pnpm`, `aikido-pnpx`, `aikido-bun`, `aikido-bunx`, `aikido-pip`, `aikido-pip3`, `aikido-uv`, `aikido-poetry` and `aikido-pipx` commands exist
+- Verify the `aikido-npm`, `aikido-npx`, `aikido-yarn`, `aikido-pnpm`, `aikido-pnpx`, `aikido-bun`, `aikido-bunx`, `aikido-pip`, `aikido-pip3`, `aikido-uv`, `aikido-uvx`, `aikido-poetry` and `aikido-pipx` commands exist
 - Check that these commands are in your system's PATH
 
 ### Manual Verification
@@ -121,7 +121,7 @@ npm() {
 }
 ```
 
-Repeat this pattern for `npx`, `yarn`, `pnpm`, `pnpx`, `bun`, `bunx`, `pip`, `pip3`, `uv`, `poetry` and `pipx` using their respective `aikido-*` commands. After adding these functions, restart your terminal to apply the changes.
+Repeat this pattern for `npx`, `yarn`, `pnpm`, `pnpx`, `bun`, `bunx`, `pip`, `pip3`, `uv`, `uvx`, `poetry` and `pipx` using their respective `aikido-*` commands. After adding these functions, restart your terminal to apply the changes.
 
 To intercept Python module invocations for pip without altering Python itself, you can add small forwarding functions:
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2417,6 +2417,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3138,6 +3139,7 @@
         "aikido-python": "bin/aikido-python.js",
         "aikido-python3": "bin/aikido-python3.js",
         "aikido-uv": "bin/aikido-uv.js",
+        "aikido-uvx": "bin/aikido-uvx.js",
         "aikido-yarn": "bin/aikido-yarn.js",
         "safe-chain": "bin/safe-chain.js"
       },

--- a/packages/safe-chain/bin/aikido-uvx.js
+++ b/packages/safe-chain/bin/aikido-uvx.js
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+
+import { main } from "../src/main.js";
+import { initializePackageManager } from "../src/packagemanager/currentPackageManager.js";
+import { setEcoSystem, ECOSYSTEM_PY } from "../src/config/settings.js";
+
+// Set eco system
+setEcoSystem(ECOSYSTEM_PY);
+
+initializePackageManager("uvx");
+
+(async () => {
+  // Pass through only user-supplied uvx args
+  var exitCode = await main(process.argv.slice(2));
+  process.exit(exitCode);
+})();

--- a/packages/safe-chain/package.json
+++ b/packages/safe-chain/package.json
@@ -16,6 +16,7 @@
     "aikido-bun": "bin/aikido-bun.js",
     "aikido-bunx": "bin/aikido-bunx.js",
     "aikido-uv": "bin/aikido-uv.js",
+    "aikido-uvx": "bin/aikido-uvx.js",
     "aikido-pip": "bin/aikido-pip.js",
     "aikido-pip3": "bin/aikido-pip3.js",
     "aikido-python": "bin/aikido-python.js",
@@ -36,7 +37,7 @@
   "keywords": [],
   "author": "Aikido Security",
   "license": "AGPL-3.0-or-later",
-  "description": "The Aikido Safe Chain wraps around the [npm cli](https://github.com/npm/cli), [npx](https://github.com/npm/cli/blob/latest/docs/content/commands/npx.md), [yarn](https://yarnpkg.com/), [pnpm](https://pnpm.io/), [pnpx](https://pnpm.io/cli/dlx), [bun](https://bun.sh/), [bunx](https://bun.sh/docs/cli/bunx), [uv](https://docs.astral.sh/uv/) (Python), and [pip](https://pip.pypa.io/) to provide extra checks before installing new packages. This tool will detect when a package contains malware and prompt you to exit, preventing npm, npx, yarn, pnpm, pnpx, bun, bunx, uv, or pip/pip3 from downloading or running the malware.",
+  "description": "The Aikido Safe Chain wraps around the [npm cli](https://github.com/npm/cli), [npx](https://github.com/npm/cli/blob/latest/docs/content/commands/npx.md), [yarn](https://yarnpkg.com/), [pnpm](https://pnpm.io/), [pnpx](https://pnpm.io/cli/dlx), [bun](https://bun.sh/), [bunx](https://bun.sh/docs/cli/bunx), [uv](https://docs.astral.sh/uv/) (Python), and [pip](https://pip.pypa.io/) to provide extra checks before installing new packages. This tool will detect when a package contains malware and prompt you to exit, preventing npm, npx, yarn, pnpm, pnpx, bun, bunx, uv, uvx, or pip/pip3 from downloading or running the malware.",
   "dependencies": {
     "certifi": "14.5.15",
     "chalk": "5.4.1",

--- a/packages/safe-chain/src/packagemanager/currentPackageManager.js
+++ b/packages/safe-chain/src/packagemanager/currentPackageManager.js
@@ -13,6 +13,7 @@ import { createPipPackageManager } from "./pip/createPackageManager.js";
 import { createUvPackageManager } from "./uv/createUvPackageManager.js";
 import { createPoetryPackageManager } from "./poetry/createPoetryPackageManager.js";
 import { createPipXPackageManager } from "./pipx/createPipXPackageManager.js";
+import { createUvxPackageManager } from "./uvx/createUvxPackageManager.js";
 
 /**
  * @type {{packageManagerName: PackageManager | null}}
@@ -60,6 +61,8 @@ export function initializePackageManager(packageManagerName, context) {
     state.packageManagerName = createPipPackageManager(context);
   } else if (packageManagerName === "uv") {
     state.packageManagerName = createUvPackageManager();
+  } else if (packageManagerName === "uvx") {
+    state.packageManagerName = createUvxPackageManager();
   } else if (packageManagerName === "poetry") {
     state.packageManagerName = createPoetryPackageManager();
   } else if (packageManagerName === "pipx") {

--- a/packages/safe-chain/src/packagemanager/uvx/createUvxPackageManager.js
+++ b/packages/safe-chain/src/packagemanager/uvx/createUvxPackageManager.js
@@ -1,0 +1,18 @@
+import { runUv } from "../uv/runUvCommand.js";
+
+/**
+ * @returns {import("../currentPackageManager.js").PackageManager}
+ */
+export function createUvxPackageManager() {
+  return {
+    /**
+     * @param {string[]} args
+     */
+    runCommand: (args) => {
+      return runUv("uvx", args);
+    },
+    // For uvx, rely solely on MITM
+    isSupportedCommand: () => false,
+    getDependencyUpdatesForCommand: () => [],
+  };
+}

--- a/packages/safe-chain/src/packagemanager/uvx/createUvxPackageManager.spec.js
+++ b/packages/safe-chain/src/packagemanager/uvx/createUvxPackageManager.spec.js
@@ -1,0 +1,14 @@
+import { test } from "node:test";
+import assert from "node:assert";
+import { createUvxPackageManager } from "./createUvxPackageManager.js";
+
+test("createUvxPackageManager returns valid package manager interface", () => {
+  const pm = createUvxPackageManager();
+
+  assert.ok(pm);
+  assert.strictEqual(typeof pm.runCommand, "function");
+  assert.strictEqual(typeof pm.isSupportedCommand, "function");
+  assert.strictEqual(typeof pm.getDependencyUpdatesForCommand, "function");
+  assert.strictEqual(pm.isSupportedCommand(), false);
+  assert.deepStrictEqual(pm.getDependencyUpdatesForCommand(), []);
+});

--- a/packages/safe-chain/src/shell-integration/helpers.js
+++ b/packages/safe-chain/src/shell-integration/helpers.js
@@ -67,6 +67,12 @@ export const knownAikidoTools = [
     internalPackageManagerName: "uv",
   },
   {
+    tool: "uvx",
+    aikidoCommand: "aikido-uvx",
+    ecoSystem: ECOSYSTEM_PY,
+    internalPackageManagerName: "uvx",
+  },
+  {
     tool: "pip",
     aikidoCommand: "aikido-pip",
     ecoSystem: ECOSYSTEM_PY,

--- a/packages/safe-chain/src/shell-integration/startup-scripts/init-fish.fish
+++ b/packages/safe-chain/src/shell-integration/startup-scripts/init-fish.fish
@@ -51,6 +51,10 @@ function uv
     wrapSafeChainCommand "uv" $argv
 end
 
+function uvx
+    wrapSafeChainCommand "uvx" $argv
+end
+
 function poetry
     wrapSafeChainCommand "poetry" $argv
 end

--- a/packages/safe-chain/src/shell-integration/startup-scripts/init-posix.sh
+++ b/packages/safe-chain/src/shell-integration/startup-scripts/init-posix.sh
@@ -47,6 +47,10 @@ function uv() {
   wrapSafeChainCommand "uv" "$@"
 }
 
+function uvx() {
+  wrapSafeChainCommand "uvx" "$@"
+}
+
 function poetry() {
   wrapSafeChainCommand "poetry" "$@"
 }

--- a/packages/safe-chain/src/shell-integration/startup-scripts/init-pwsh.ps1
+++ b/packages/safe-chain/src/shell-integration/startup-scripts/init-pwsh.ps1
@@ -52,6 +52,10 @@ function uv {
     Invoke-WrappedCommand "uv" $args $MyInvocation.Line $MyInvocation.OffsetInLine
 }
 
+function uvx {
+    Invoke-WrappedCommand "uvx" $args $MyInvocation.Line $MyInvocation.OffsetInLine
+}
+
 function poetry {
     Invoke-WrappedCommand "poetry" $args $MyInvocation.Line $MyInvocation.OffsetInLine
 }

--- a/test/e2e/uvx.e2e.spec.js
+++ b/test/e2e/uvx.e2e.spec.js
@@ -1,0 +1,132 @@
+import { describe, it, before, beforeEach, afterEach } from "node:test";
+import { DockerTestContainer } from "./DockerTestContainer.js";
+import assert from "node:assert";
+
+describe("E2E: uvx coverage", () => {
+  let container;
+
+  before(async () => {
+    DockerTestContainer.buildImage();
+  });
+
+  beforeEach(async () => {
+    container = new DockerTestContainer();
+    await container.start();
+
+    const installationShell = await container.openShell("zsh");
+    await installationShell.runCommand("safe-chain setup");
+
+    // Clear uv cache
+    await installationShell.runCommand("uv cache clean");
+  });
+
+  afterEach(async () => {
+    if (container) {
+      await container.stop();
+      container = null;
+    }
+  });
+
+  it(`successfully runs a known safe tool with uvx`, async () => {
+    const shell = await container.openShell("zsh");
+
+    const result = await shell.runCommand(
+      "uvx ruff --version --safe-chain-logging=verbose"
+    );
+
+    assert.ok(
+      result.output.includes("no malware found.") || /ruff/i.test(result.output),
+      `Expected safe tool to run successfully. Output was:\n${result.output}`
+    );
+  });
+
+  it(`safe-chain blocks malicious packages via uvx`, async () => {
+    const shell = await container.openShell("zsh");
+
+    const result = await shell.runCommand(
+      "uvx safe-chain-pi-test"
+    );
+
+    assert.ok(
+      result.output.includes("blocked by safe-chain"),
+      `Expected malicious package to be blocked. Output was:\n${result.output}`
+    );
+    assert.ok(
+      result.output.includes("Exiting without installing malicious packages."),
+      `Expected exit message. Output was:\n${result.output}`
+    );
+  });
+
+  it(`uvx with --from flag runs a safe tool`, async () => {
+    const shell = await container.openShell("zsh");
+
+    const result = await shell.runCommand(
+      "uvx --from ruff ruff --version --safe-chain-logging=verbose"
+    );
+
+    assert.ok(
+      result.output.includes("no malware found.") || /ruff/i.test(result.output),
+      `Expected safe tool to run successfully with --from. Output was:\n${result.output}`
+    );
+  });
+
+  it(`uvx with --from flag blocks malicious packages`, async () => {
+    const shell = await container.openShell("zsh");
+
+    const result = await shell.runCommand(
+      "uvx --from safe-chain-pi-test some-command"
+    );
+
+    assert.ok(
+      result.output.includes("blocked by safe-chain"),
+      `Expected malicious package to be blocked with --from. Output was:\n${result.output}`
+    );
+    assert.ok(
+      result.output.includes("Exiting without installing malicious packages."),
+      `Expected exit message. Output was:\n${result.output}`
+    );
+  });
+
+  it(`uvx with specific version runs successfully`, async () => {
+    const shell = await container.openShell("zsh");
+
+    const result = await shell.runCommand(
+      "uvx ruff@0.4.0 --version --safe-chain-logging=verbose"
+    );
+
+    assert.ok(
+      result.output.includes("no malware found.") || /ruff/i.test(result.output),
+      `Expected safe tool with version to run. Output was:\n${result.output}`
+    );
+  });
+
+  it(`uvx with --with flag for additional dependencies`, async () => {
+    const shell = await container.openShell("zsh");
+
+    const result = await shell.runCommand(
+      "uvx --with requests ruff --version --safe-chain-logging=verbose"
+    );
+
+    assert.ok(
+      result.output.includes("no malware found.") || /ruff/i.test(result.output),
+      `Expected safe tool with --with dependency to run. Output was:\n${result.output}`
+    );
+  });
+
+  it(`uvx with --with flag blocks malicious additional dependencies`, async () => {
+    const shell = await container.openShell("zsh");
+
+    const result = await shell.runCommand(
+      "uvx --with safe-chain-pi-test ruff --version"
+    );
+
+    assert.ok(
+      result.output.includes("blocked by safe-chain"),
+      `Expected malicious --with dependency to be blocked. Output was:\n${result.output}`
+    );
+    assert.ok(
+      result.output.includes("Exiting without installing malicious packages."),
+      `Expected exit message. Output was:\n${result.output}`
+    );
+  });
+});


### PR DESCRIPTION
Add uvx as a supported package manager so that `uvx` commands are routed through safe-chain's MITM proxy for malware detection, just like `uv`. Previously, `uvx` bypassed all safe-chain protections.

The uvx package manager reuses the existing uv command runner since uvx is functionally equivalent to `uv tool run`.

Fixes #268

<img width="1352" height="215" alt="image" src="https://github.com/user-attachments/assets/688fc276-064e-46d1-a7d7-a6a9ec606a1d" />

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🚀 New Features**
* Added uvx package manager support with MITM routing and tests

**📚 Documentation**
* Updated package metadata and CLI bin entries to include uvx


<sup>[More info](https://app.aikido.dev/featurebranch/scan/103677543?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->