### PR TITLE
Restore back to ubuntu runners

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -85,27 +85,37 @@ jobs:
           cp install-scripts/uninstall-endpoint-mac.sh release-artifacts/uninstall-endpoint-mac.sh
           cp install-scripts/uninstall-endpoint-windows.ps1 release-artifacts/uninstall-endpoint-windows.ps1
 
-      - name: Upload binaries to existing GitHub Release
+
+      - name: Upload all assets to release
+        uses: softprops/action-gh-release@6cbd405e2c4e67a21c47fa9e383d020e4e28b836 # v2.3.3
+        with:
+          files: |
+            release-artifacts/safe-chain-macos-x64
+            release-artifacts/safe-chain-macos-arm64
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release upload ${{ needs.set-version.outputs.version }} \
-            release-artifacts/safe-chain-macos-x64 \
-            release-artifacts/safe-chain-macos-arm64 \
-            release-artifacts/safe-chain-linux-x64 \
-            release-artifacts/safe-chain-linux-arm64 \
-            release-artifacts/safe-chain-linuxstatic-x64 \
-            release-artifacts/safe-chain-linuxstatic-arm64 \
-            release-artifacts/safe-chain-win-x64.exe \
-            release-artifacts/safe-chain-win-arm64.exe \
-            release-artifacts/install-safe-chain.sh \
-            release-artifacts/install-safe-chain.ps1 \
-            release-artifacts/uninstall-safe-chain.sh \
-            release-artifacts/uninstall-safe-chain.ps1 \
-            release-artifacts/install-endpoint-mac.sh \
-            release-artifacts/install-endpoint-windows.ps1 \
-            release-artifacts/uninstall-endpoint-mac.sh \
-            release-artifacts/uninstall-endpoint-windows.ps1
+
+      # - name: Upload binaries to existing GitHub Release
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   run: |
+      #     gh release upload ${{ needs.set-version.outputs.version }} \
+      #       release-artifacts/safe-chain-macos-x64 \
+      #       release-artifacts/safe-chain-macos-arm64 \
+      #       release-artifacts/safe-chain-linux-x64 \
+      #       release-artifacts/safe-chain-linux-arm64 \
+      #       release-artifacts/safe-chain-linuxstatic-x64 \
+      #       release-artifacts/safe-chain-linuxstatic-arm64 \
+      #       release-artifacts/safe-chain-win-x64.exe \
+      #       release-artifacts/safe-chain-win-arm64.exe \
+      #       release-artifacts/install-safe-chain.sh \
+      #       release-artifacts/install-safe-chain.ps1 \
+      #       release-artifacts/uninstall-safe-chain.sh \
+      #       release-artifacts/uninstall-safe-chain.ps1 \
+      #       release-artifacts/install-endpoint-mac.sh \
+      #       release-artifacts/install-endpoint-windows.ps1 \
+      #       release-artifacts/uninstall-endpoint-mac.sh \
+      #       release-artifacts/uninstall-endpoint-windows.ps1
 
   publish-npm:
     name: Publish to npm

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   set-version:
     name: Set version number
-    runs-on: standard-runner-no-rights-public-ip
+    runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.get_version.outputs.tag }}
       is_prerelease: ${{ steps.check_prerelease.outputs.is_prerelease }}
@@ -28,12 +28,15 @@ jobs:
 
       - name: Check if pre-release
         id: check_prerelease
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          IS_PRERELEASE=$(gh release view ${{ steps.get_version.outputs.tag }} --json isPrerelease --jq '.isPrerelease')
+          TAG="${{ steps.get_version.outputs.tag }}"
+          if [[ "$TAG" == *-* ]]; then
+            IS_PRERELEASE=true
+          else
+            IS_PRERELEASE=false
+          fi
           echo "is_prerelease=$IS_PRERELEASE" >> $GITHUB_OUTPUT
-          echo "Release ${{ steps.get_version.outputs.tag }} is pre-release: $IS_PRERELEASE"
+          echo "Release $TAG is pre-release: $IS_PRERELEASE"
 
   create-binaries:
     needs: set-version
@@ -44,7 +47,7 @@ jobs:
   publish-binaries:
     name: Publish to GitHub release
     needs: [set-version, create-binaries]
-    runs-on: standard-runner-no-rights-public-ip
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Reverted custom runners to ubuntu-latest for CI jobs
* Replaced gh release upload with softprops/action-gh-release action step

**🔧 Refactors**
* Changed prerelease detection to tag string heuristic instead of gh


<sup>[More info](https://app.aikido.dev/featurebranch/scan/96611439?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->