### PR TITLE
Change runner to open-source-releaser in workflow

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   set-version:
     name: Set version number
-    runs-on: standard-runner-no-rights-public-ip
+    runs-on: open-source-releaser
     outputs:
       version: ${{ steps.get_version.outputs.tag }}
       is_prerelease: ${{ steps.check_prerelease.outputs.is_prerelease }}
@@ -44,8 +44,7 @@ jobs:
   publish-binaries:
     name: Publish to GitHub release
     needs: [set-version, create-binaries]
-    runs-on: standard-runner-no-rights-public-ip
-
+    runs-on: open-source-releaser
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Replaced custom runner with open-source-releaser for release jobs


<sup>[More info](https://app.aikido.dev/featurebranch/scan/96680681?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->