### PR TITLE
Fix releases to create draft

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - "*"
+  release:
+    types: [published]
 
 permissions:
   id-token: write
@@ -12,30 +14,19 @@ permissions:
 jobs:
   set-version:
     name: Set version number
+    if: github.event_name == 'push'
     runs-on: open-source-releaser
     outputs:
       version: ${{ steps.get_version.outputs.tag }}
-      is_prerelease: ${{ steps.check_prerelease.outputs.is_prerelease }}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
       - name: Set version number
         id: get_version
         run: |
           version="${{ github.ref_name }}"
           echo "tag=$version" >> $GITHUB_OUTPUT
 
-      - name: Check if pre-release
-        id: check_prerelease
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          IS_PRERELEASE=$(gh release view ${{ steps.get_version.outputs.tag }} --json isPrerelease --jq '.isPrerelease')
-          echo "is_prerelease=$IS_PRERELEASE" >> $GITHUB_OUTPUT
-          echo "Release ${{ steps.get_version.outputs.tag }} is pre-release: $IS_PRERELEASE"
-
   create-binaries:
+    if: github.event_name == 'push'
     needs: set-version
     uses: ./.github/workflows/create-artifact.yml
     with:
@@ -43,6 +34,7 @@ jobs:
 
   publish-binaries:
     name: Publish to GitHub release
+    if: github.event_name == 'push'
     needs: [set-version, create-binaries]
     runs-on: open-source-releaser
     steps:
@@ -81,11 +73,15 @@ jobs:
           cp install-scripts/uninstall-endpoint-mac.sh release-artifacts/uninstall-endpoint-mac.sh
           cp install-scripts/uninstall-endpoint-windows.ps1 release-artifacts/uninstall-endpoint-windows.ps1
 
-      - name: Upload binaries to existing GitHub Release
+      - name: Create draft release and upload assets
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.set-version.outputs.version }}
         run: |
-          gh release upload ${{ needs.set-version.outputs.version }} \
+          if ! gh release view "$VERSION" &>/dev/null; then
+            gh release create "$VERSION" --draft --title "$VERSION" --generate-notes
+          fi
+          gh release upload "$VERSION" --clobber \
             release-artifacts/safe-chain-macos-x64 \
             release-artifacts/safe-chain-macos-arm64 \
             release-artifacts/safe-chain-linux-x64 \
@@ -105,8 +101,7 @@ jobs:
 
   publish-npm:
     name: Publish to npm
-    needs: [set-version, create-binaries]
-    if: needs.set-version.outputs.is_prerelease != 'true'
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
 
     steps:
@@ -125,7 +120,7 @@ jobs:
         run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
 
       - name: Set the version in safe-chain package
-        run: npm --no-git-tag-version version ${{ needs.set-version.outputs.version }} --workspace=packages/safe-chain
+        run: npm --no-git-tag-version version ${{ github.event.release.tag_name }} --workspace=packages/safe-chain
 
       - name: Install dependencies
         run: npm ci
@@ -141,5 +136,5 @@ jobs:
 
       - name: Publish to npm
         run: |
-          echo "Publishing version ${{ needs.set-version.outputs.version }} to NPM"
+          echo "Publishing version ${{ github.event.release.tag_name }} to NPM"
           npm publish --workspace=packages/safe-chain --access public --provenance


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Created draft GitHub releases if missing and uploaded built assets
* Changed publish-npm to run on release events using release tag
* Added event-name guards so build jobs only ran on push

**🔧 Refactors**
* Removed prerelease detection step and its outputs from workflow


<sup>[More info](https://app.aikido.dev/featurebranch/scan/99835586?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->