### PR TITLE
[security] action sha pinning - Addresses issue 378

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -39,10 +39,10 @@ jobs:
     runs-on: open-source-releaser
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Download all binary artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: binaries/
           pattern: safe-chain-*
@@ -105,10 +105,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "lts/*"
           registry-url: "https://registry.npmjs.org/"

--- a/.github/workflows/create-artifact.yml
+++ b/.github/workflows/create-artifact.yml
@@ -62,10 +62,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20.x"
 
@@ -88,7 +88,7 @@ jobs:
           node build.js ${{ matrix.target }}
 
       - name: Upload binary artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: safe-chain-${{ matrix.os }}-${{ matrix.arch }}
           path: dist/*

--- a/.github/workflows/test-on-pr.yml
+++ b/.github/workflows/test-on-pr.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "lts/*"
 
@@ -43,7 +43,7 @@ jobs:
         run: npm pack --workspace=packages/safe-chain
 
       - name: Upload package tarball
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: matrix.os == 'ubuntu-latest'
         with:
           name: safe-chain-package
@@ -101,10 +101,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "lts/*"
 


### PR DESCRIPTION
Summary
Pins first-party GitHub Actions to full commit SHAs and aligns all workflows on the same v4 versions of actions/checkout, actions/setup-node, actions/upload-artifact, and actions/download-artifact.

Inspired by issue https://github.com/AikidoSec/safe-chain/issues/378

Why
Tag-based refs (@v4) can move if the tag is updated. Pinning to SHAs matches GitHub’s guidance for supply-chain safety and keeps CI using a known immutable revision.

Changes
Replace @v3 / @v4 tags with pinned SHAs and short # v4 comments where helpful.
Use actions/checkout@v4 and actions/setup-node@v4 consistently across test-on-pr.yml, create-artifact.yml, and build-and-release.yml.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Pinned GitHub Actions refs to full commit SHAs for security
* Aligned workflows to consistent v4 versions of core actions


<sup>[More info](https://app.aikido.dev/featurebranch/scan/100800391?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->