### PR TITLE
Clean up shell init when running setup-ci

### DIFF
--- a/packages/safe-chain/src/shell-integration/setup-ci.js
+++ b/packages/safe-chain/src/shell-integration/setup-ci.js
@@ -52,9 +52,8 @@ function cleanupLegacyShellInit() {
   let shells;
   try {
     shells = detectShells();
-  } catch (error) {
+  } catch {
     // Best-effort cleanup — skip if shell detection fails
-    console.warn("Failed to detect shells for legacy cleanup:", error);
     return;
   }
 

--- a/packages/safe-chain/src/shell-integration/setup-ci.js
+++ b/packages/safe-chain/src/shell-integration/setup-ci.js
@@ -1,6 +1,7 @@
 import chalk from "chalk";
 import { ui } from "../environment/userInteraction.js";
 import { getPackageManagerList, knownAikidoTools, getShimsDir } from "./helpers.js";
+import { detectShells } from "./shellDetection.js";
 import fs from "fs";
 import os from "os";
 import path from "path";
@@ -37,10 +38,31 @@ export async function setupCi() {
     fs.mkdirSync(shimsDir, { recursive: true });
   }
 
+  cleanupLegacyShellInit();
   createShims(shimsDir);
   ui.writeInformation(`Created shims in ${shimsDir}`);
   modifyPathForCi(shimsDir, binDir);
   ui.writeInformation(`Added shims directory to PATH for CI environments.`);
+}
+
+/**
+ * Removes shell-based initialization from RC files when switching to --ci install mode.
+ */
+function cleanupLegacyShellInit() {
+  let shells;
+  try {
+    shells = detectShells();
+  } catch {
+    return;
+  }
+
+  for (const shell of shells) {
+    try {
+      shell.teardown(knownAikidoTools);
+    } catch {
+      // Best-effort cleanup — don't fail the install if teardown errors
+    }
+  }
 }
 
 /**

--- a/packages/safe-chain/src/shell-integration/setup-ci.js
+++ b/packages/safe-chain/src/shell-integration/setup-ci.js
@@ -52,7 +52,9 @@ function cleanupLegacyShellInit() {
   let shells;
   try {
     shells = detectShells();
-  } catch {
+  } catch (error) {
+    // Best-effort cleanup — skip if shell detection fails
+    console.warn("Failed to detect shells for legacy cleanup:", error);
     return;
   }
 

--- a/packages/safe-chain/src/shell-integration/setup-ci.spec.js
+++ b/packages/safe-chain/src/shell-integration/setup-ci.spec.js
@@ -42,6 +42,13 @@ describe("Setup CI shell integration", () => {
       },
     });
 
+    // Mock shell detection to avoid touching real RC files during tests
+    mock.module("./shellDetection.js", {
+      namedExports: {
+        detectShells: () => [],
+      },
+    });
+
     // Mock the helpers module
     mock.module("./helpers.js", {
       namedExports: {

--- a/test/e2e/setup-ci.e2e.spec.js
+++ b/test/e2e/setup-ci.e2e.spec.js
@@ -53,6 +53,46 @@ describe("E2E: safe-chain setup-ci command", () => {
     });
   }
 
+  for (let shell of ["bash", "zsh"]) {
+    it(`safe-chain setup-ci removes legacy shell init left by a previous setup for ${shell}`, async () => {
+      const rcFile = shell === "zsh" ? "~/.zshrc" : "~/.bashrc";
+
+      // Simulate a previous non-CI install
+      const installationShell = await container.openShell(shell);
+      await installationShell.runCommand("safe-chain setup");
+
+      // Verify the legacy init line was added
+      const afterSetup = await installationShell.runCommand(`grep -c "init-posix.sh" ${rcFile} || true`);
+      assert.ok(
+        afterSetup.output.includes("1"),
+        `Expected init-posix.sh to be present in ${rcFile} after setup`
+      );
+
+      // Now run the CI install — should clean up the legacy line
+      await installationShell.runCommand("safe-chain setup-ci");
+      await installationShell.runCommand(
+        `echo 'export PATH="$HOME/.safe-chain/shims:$PATH"' >> ${rcFile}`
+      );
+
+      const afterSetupCi = await installationShell.runCommand(`grep -c "init-posix.sh" ${rcFile} || true`);
+      assert.ok(
+        !afterSetupCi.output.includes("1"),
+        `Expected init-posix.sh to be removed from ${rcFile} after setup-ci, but it was still present`
+      );
+
+      // Verify npm still works through shims in a new shell
+      const projectShell = await container.openShell(shell);
+      const result = await projectShell.runCommand(
+        "npm i axios@1.13.0 --safe-chain-logging=verbose"
+      );
+
+      assert.ok(
+        result.output.includes("Safe-chain: Scanned"),
+        `Expected npm to be wrapped by safe-chain shim after setup-ci.\nOutput was:\n${result.output}`
+      );
+    });
+  }
+
   it("writes to GITHUB_PATH when GITHUB_PATH is set", async () => {
     const installationShell = await container.openShell("zsh");
     await installationShell.runCommand("export GITHUB_PATH=/tmp/github_path");


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Removed legacy shell initialization from rc files during CI setup.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/101240632?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->