### PR TITLE
Remove Node 16 from test matrix

### DIFF
--- a/.github/workflows/test-on-pr.yml
+++ b/.github/workflows/test-on-pr.yml
@@ -93,11 +93,6 @@ jobs:
             npm_version: "latest"
             yarn_version: "latest"
             pnpm_version: "latest"
-          # EOL compatibility testing - Node 16 (EOL Sept 2023)
-          - node_version: "16"
-            npm_version: "8.0.0"
-            yarn_version: "1.22.0"
-            pnpm_version: "8.0.0"
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Removed Node 16 entries from E2E test matrix in CI


<sup>[More info](https://app.aikido.dev/featurebranch/scan/102480291?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->

Node 16 is EOL and diagnostics_channel.tracingChannel() — 
added in Node 18 — causes a TypeError during testing.