### PR TITLE
Update Aikido Endpoint package download version to 1.2.16

### DIFF
--- a/install-scripts/install-endpoint-mac.sh
+++ b/install-scripts/install-endpoint-mac.sh
@@ -7,8 +7,8 @@
 set -e  # Exit on error
 
 # Configuration
-INSTALL_URL="https://github.com/AikidoSec/safechain-internals/releases/download/v1.2.13/EndpointProtection.pkg"
-DOWNLOAD_SHA256="ab68536dad46625aff19897e0191f3b84c8facf36e07852854bb868e46bfe28a"
+INSTALL_URL="https://github.com/AikidoSec/safechain-internals/releases/download/v1.2.16/EndpointProtection.pkg"
+DOWNLOAD_SHA256="6c185d247093533e44c1547c10e32bed899b6313b51d8bf74bcf3ddc08d8d824"
 TOKEN_FILE="/tmp/aikido_endpoint_token.txt"
 
 # Colors for output

--- a/install-scripts/install-endpoint-windows.ps1
+++ b/install-scripts/install-endpoint-windows.ps1
@@ -7,8 +7,8 @@ param(
 )
 
 # Configuration
-$InstallUrl = "https://github.com/AikidoSec/safechain-internals/releases/download/v1.2.13/EndpointProtection.msi"
-$DownloadSha256 = "9005700b23c8214816642eea741a584c694d19c0eeb26deebf560092f4e5d568"
+$InstallUrl = "https://github.com/AikidoSec/safechain-internals/releases/download/v1.2.16/EndpointProtection.msi"
+$DownloadSha256 = "5284c7a8078a02439733b02f66158ac6a7cb09bbb9fba38ec2ff8d98b494e637"
 
 # Ensure TLS 1.2 is enabled for downloads
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Updated Windows installer download URL and SHA256 checksum to 1.2.16
* Updated macOS installer download URL and SHA256 checksum to 1.2.16


<sup>[More info](https://app.aikido.dev/featurebranch/scan/103103852?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->