### PR TITLE
Fix environment variable merging to allow empty string values

### DIFF
--- a/packages/safe-chain/src/registryProxy/registryProxy.environment-variables.spec.js
+++ b/packages/safe-chain/src/registryProxy/registryProxy.environment-variables.spec.js
@@ -1,0 +1,13 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { mergeSafeChainProxyEnvironmentVariables } from "./registryProxy.js";
+
+describe("registryProxy.environmentVariables", () => {
+  it("should copy environment variables with empty string values", () => {
+    const envVars = mergeSafeChainProxyEnvironmentVariables({
+      EMPTY_VAR: "",
+    });
+
+    assert.strictEqual(envVars.EMPTY_VAR, "");
+  });
+});

--- a/packages/safe-chain/src/registryProxy/registryProxy.js
+++ b/packages/safe-chain/src/registryProxy/registryProxy.js
@@ -66,7 +66,7 @@ export function mergeSafeChainProxyEnvironmentVariables(env) {
     // So we only copy the variable if it's not already set in a different case
     const upperKey = key.toUpperCase();
 
-    if (!proxyEnv[upperKey] && env[key]) {
+    if (!(upperKey in proxyEnv) && env[key] !== undefined) {
       proxyEnv[key] = env[key];
     }
   }


### PR DESCRIPTION
This pull request fixes the logic in mergeSafeChainProxyEnvironmentVariables to ensure that environment variables with empty string values are correctly copied.
A corresponding test has been added to verify this behavior.

- Fixes an issue where empty string values were previously ignored
- Adds a unit test to cover this case


<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Allowed empty string environment variables to be preserved during merge


<sup>[More info](https://app.aikido.dev/featurebranch/scan/103848735?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->