### PR TITLE
fix(shell-init): suppress `cd` output

### DIFF
--- a/packages/safe-chain/src/shell-integration/path-wrappers/templates/unix-wrapper.template.sh
+++ b/packages/safe-chain/src/shell-integration/path-wrappers/templates/unix-wrapper.template.sh
@@ -4,7 +4,7 @@
 
 # Function to remove shim from PATH (POSIX-compliant)
 remove_shim_from_path() {
-    _safe_chain_phys=$(CDPATH= cd -- "$(dirname -- "$0")" 2>/dev/null && pwd -P)
+    _safe_chain_phys=$(CDPATH= cd -- "$(dirname -- "$0")" >/dev/null 2>/dev/null && pwd -P)
     if [ -z "$_safe_chain_phys" ]; then
         echo "$PATH"
         return

--- a/packages/safe-chain/src/shell-integration/startup-scripts/init-posix.sh
+++ b/packages/safe-chain/src/shell-integration/startup-scripts/init-posix.sh
@@ -7,7 +7,7 @@ elif [ -n "${ZSH_VERSION:-}" ]; then
 else
     _sc_script_path="$0"
 fi
-_sc_scripts_dir=$(CDPATH= cd -- "$(dirname -- "$_sc_script_path")" 2>/dev/null && pwd -P)
+_sc_scripts_dir=$(CDPATH= cd -- "$(dirname -- "$_sc_script_path")" >/dev/null 2>/dev/null && pwd -P)
 _sc_base=$(dirname -- "$_sc_scripts_dir")
 export PATH="$PATH:${_sc_base}/bin"
 unset _sc_base _sc_script_path _sc_scripts_dir


### PR DESCRIPTION
If `cd` causes output on stdout (e.g., via the use of noisy `chpwd` hooks on zsh), then the resultant `PATH` exported to the shell will be polluted with that output, and `safe-chain` will not function.  To prevent this, this PR updates `init-posix.sh` and `unix-wrapper.template.sh` to suppress any output on stdout during `cd`.

You can reproduce the original issue by configuring `.zshrc` as follows and launching a new shell:
```sh
PATH="/bin:/usr/bin:/usr/local/bin" # minimal PATH
myfunc() {
  echo "blah"
}
autoload -U add-zsh-hook
add-zsh-hook chpwd myfunc
set -x
source ~/.safe-chain/scripts/init-posix.sh # Safe-chain bash initialization script
set +x
```

<img width="888" height="422" alt="Screenshot 2026-04-29 at 09 29 02" src="https://github.com/user-attachments/assets/097aa812-56e9-4654-b6a6-36d255ed2f71" />



