### PR TITLE
Add binary checksum validation in safe-chain install scripts

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -60,12 +60,43 @@ jobs:
           mv binaries/safe-chain-win-x64/safe-chain.exe release-artifacts/safe-chain-win-x64.exe
           mv binaries/safe-chain-win-arm64/safe-chain.exe release-artifacts/safe-chain-win-arm64.exe
 
-      - name: Move install scripts and hard-code version
+      - name: Move install scripts and hard-code version and checksums
         env:
           VERSION: ${{ needs.set-version.outputs.version }}
         run: |
-          sed "s/\$(fetch_latest_version)/${VERSION}/" install-scripts/install-safe-chain.sh > release-artifacts/install-safe-chain.sh
-          sed "s/\$Version = Get-LatestVersion/\$Version = \"${VERSION}\"/" install-scripts/install-safe-chain.ps1 > release-artifacts/install-safe-chain.ps1
+          SHA_MACOS_X64=$(sha256sum release-artifacts/safe-chain-macos-x64         | awk '{print $1}')
+          SHA_MACOS_ARM64=$(sha256sum release-artifacts/safe-chain-macos-arm64     | awk '{print $1}')
+          SHA_LINUX_X64=$(sha256sum release-artifacts/safe-chain-linux-x64         | awk '{print $1}')
+          SHA_LINUX_ARM64=$(sha256sum release-artifacts/safe-chain-linux-arm64     | awk '{print $1}')
+          SHA_LINUXSTATIC_X64=$(sha256sum release-artifacts/safe-chain-linuxstatic-x64     | awk '{print $1}')
+          SHA_LINUXSTATIC_ARM64=$(sha256sum release-artifacts/safe-chain-linuxstatic-arm64 | awk '{print $1}')
+          SHA_WIN_X64=$(sha256sum release-artifacts/safe-chain-win-x64.exe         | awk '{print $1}')
+          SHA_WIN_ARM64=$(sha256sum release-artifacts/safe-chain-win-arm64.exe     | awk '{print $1}')
+
+          sed \
+            -e "s/\$(fetch_latest_version)/${VERSION}/" \
+            -e "s|^SHA256_MACOS_X64=\"\"|SHA256_MACOS_X64=\"${SHA_MACOS_X64}\"|" \
+            -e "s|^SHA256_MACOS_ARM64=\"\"|SHA256_MACOS_ARM64=\"${SHA_MACOS_ARM64}\"|" \
+            -e "s|^SHA256_LINUX_X64=\"\"|SHA256_LINUX_X64=\"${SHA_LINUX_X64}\"|" \
+            -e "s|^SHA256_LINUX_ARM64=\"\"|SHA256_LINUX_ARM64=\"${SHA_LINUX_ARM64}\"|" \
+            -e "s|^SHA256_LINUXSTATIC_X64=\"\"|SHA256_LINUXSTATIC_X64=\"${SHA_LINUXSTATIC_X64}\"|" \
+            -e "s|^SHA256_LINUXSTATIC_ARM64=\"\"|SHA256_LINUXSTATIC_ARM64=\"${SHA_LINUXSTATIC_ARM64}\"|" \
+            -e "s|^SHA256_WIN_X64=\"\"|SHA256_WIN_X64=\"${SHA_WIN_X64}\"|" \
+            -e "s|^SHA256_WIN_ARM64=\"\"|SHA256_WIN_ARM64=\"${SHA_WIN_ARM64}\"|" \
+            install-scripts/install-safe-chain.sh > release-artifacts/install-safe-chain.sh
+
+          sed \
+            -e "s/\$Version = Get-LatestVersion/\$Version = \"${VERSION}\"/" \
+            -e "s|^\$SHA256_MACOS_X64 = \"\"|\$SHA256_MACOS_X64 = \"${SHA_MACOS_X64}\"|" \
+            -e "s|^\$SHA256_MACOS_ARM64 = \"\"|\$SHA256_MACOS_ARM64 = \"${SHA_MACOS_ARM64}\"|" \
+            -e "s|^\$SHA256_LINUX_X64 = \"\"|\$SHA256_LINUX_X64 = \"${SHA_LINUX_X64}\"|" \
+            -e "s|^\$SHA256_LINUX_ARM64 = \"\"|\$SHA256_LINUX_ARM64 = \"${SHA_LINUX_ARM64}\"|" \
+            -e "s|^\$SHA256_LINUXSTATIC_X64 = \"\"|\$SHA256_LINUXSTATIC_X64 = \"${SHA_LINUXSTATIC_X64}\"|" \
+            -e "s|^\$SHA256_LINUXSTATIC_ARM64 = \"\"|\$SHA256_LINUXSTATIC_ARM64 = \"${SHA_LINUXSTATIC_ARM64}\"|" \
+            -e "s|^\$SHA256_WIN_X64 = \"\"|\$SHA256_WIN_X64 = \"${SHA_WIN_X64}\"|" \
+            -e "s|^\$SHA256_WIN_ARM64 = \"\"|\$SHA256_WIN_ARM64 = \"${SHA_WIN_ARM64}\"|" \
+            install-scripts/install-safe-chain.ps1 > release-artifacts/install-safe-chain.ps1
+
           cp install-scripts/uninstall-safe-chain.sh release-artifacts/uninstall-safe-chain.sh
           cp install-scripts/uninstall-safe-chain.ps1 release-artifacts/uninstall-safe-chain.ps1
           cp install-scripts/install-endpoint-mac.sh release-artifacts/install-endpoint-mac.sh

--- a/install-scripts/install-safe-chain.ps1
+++ b/install-scripts/install-safe-chain.ps1
@@ -52,6 +52,20 @@ $SafeChainBase = $installDirValidation.Normalized
 $InstallDir = Join-Path $SafeChainBase "bin"
 $RepoUrl = "https://github.com/AikidoSec/safe-chain"
 
+# SHA256 checksums for release binaries.
+# Empty in source; populated by the release pipeline.
+# When empty (running from main), checksum verification is skipped.
+# Non-Windows hashes are unused today (PS script is Windows-only) but baked in
+# for future cross-platform support.
+$SHA256_MACOS_X64 = ""
+$SHA256_MACOS_ARM64 = ""
+$SHA256_LINUX_X64 = ""
+$SHA256_LINUX_ARM64 = ""
+$SHA256_LINUXSTATIC_X64 = ""
+$SHA256_LINUXSTATIC_ARM64 = ""
+$SHA256_WIN_X64 = ""
+$SHA256_WIN_ARM64 = ""
+
 # Ensure TLS 1.2 is enabled for downloads
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
@@ -164,6 +178,38 @@ function Get-BinaryName {
     param([string]$Architecture)
 
     return "safe-chain-win-$Architecture.exe"
+}
+
+# Returns the expected SHA256 for the given OS+arch, or empty if not baked in.
+function Get-ExpectedSha256 {
+    param([string]$Os, [string]$Architecture)
+    switch ("$Os-$Architecture") {
+        "macos-x64"         { return $SHA256_MACOS_X64 }
+        "macos-arm64"       { return $SHA256_MACOS_ARM64 }
+        "linux-x64"         { return $SHA256_LINUX_X64 }
+        "linux-arm64"       { return $SHA256_LINUX_ARM64 }
+        "linuxstatic-x64"   { return $SHA256_LINUXSTATIC_X64 }
+        "linuxstatic-arm64" { return $SHA256_LINUXSTATIC_ARM64 }
+        "win-x64"           { return $SHA256_WIN_X64 }
+        "win-arm64"         { return $SHA256_WIN_ARM64 }
+        default             { return "" }
+    }
+}
+
+function Test-Checksum {
+    param([string]$File, [string]$Expected)
+
+    if ([string]::IsNullOrWhiteSpace($Expected)) { return }
+
+    $actual = (Get-FileHash -Path $File -Algorithm SHA256).Hash.ToLowerInvariant()
+    $expectedLower = $Expected.ToLowerInvariant()
+
+    if ($actual -ne $expectedLower) {
+        Remove-Item -Path $File -Force -ErrorAction SilentlyContinue
+        Write-Error-Custom "Checksum verification failed. Expected: $expectedLower, Got: $actual"
+    }
+
+    Write-Info "Checksum verified."
 }
 
 # Runs safe-chain setup or setup-ci after the binary is installed.
@@ -304,6 +350,9 @@ function Install-SafeChain {
     catch {
         Write-Error-Custom "Failed to download from $downloadUrl : $_"
     }
+
+    $expectedSha = Get-ExpectedSha256 -Os "win" -Architecture $arch
+    Test-Checksum -File $tempFile -Expected $expectedSha
 
     # Rename to final location
     $finalFile = Join-Path $InstallDir "safe-chain.exe"

--- a/install-scripts/install-safe-chain.sh
+++ b/install-scripts/install-safe-chain.sh
@@ -55,6 +55,18 @@ SAFE_CHAIN_BASE="${HOME}/.safe-chain"
 INSTALL_DIR="${SAFE_CHAIN_BASE}/bin"
 REPO_URL="https://github.com/AikidoSec/safe-chain"
 
+# SHA256 checksums for release binaries.
+# Empty in source; populated by the release pipeline via sed.
+# When empty (running from main), checksum verification is skipped.
+SHA256_MACOS_X64=""
+SHA256_MACOS_ARM64=""
+SHA256_LINUX_X64=""
+SHA256_LINUX_ARM64=""
+SHA256_LINUXSTATIC_X64=""
+SHA256_LINUXSTATIC_ARM64=""
+SHA256_WIN_X64=""
+SHA256_WIN_ARM64=""
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -154,6 +166,57 @@ fetch_latest_version() {
     fi
 
     echo "$latest_version"
+}
+
+# Returns the expected SHA256 for the detected platform, or empty if the
+# release pipeline has not baked one in (i.e. running the source from main).
+get_expected_sha256() {
+    os="$1"; arch="$2"
+    case "${os}-${arch}" in
+        macos-x64)         echo "$SHA256_MACOS_X64" ;;
+        macos-arm64)       echo "$SHA256_MACOS_ARM64" ;;
+        linux-x64)         echo "$SHA256_LINUX_X64" ;;
+        linux-arm64)       echo "$SHA256_LINUX_ARM64" ;;
+        linuxstatic-x64)   echo "$SHA256_LINUXSTATIC_X64" ;;
+        linuxstatic-arm64) echo "$SHA256_LINUXSTATIC_ARM64" ;;
+        win-x64)           echo "$SHA256_WIN_X64" ;;
+        win-arm64)         echo "$SHA256_WIN_ARM64" ;;
+        *)                 echo "" ;;
+    esac
+}
+
+compute_sha256() {
+    file="$1"
+    if command_exists sha256sum; then
+        sha256sum "$file" | awk '{print $1}'
+    elif command_exists shasum; then
+        shasum -a 256 "$file" | awk '{print $1}'
+    else
+        echo ""
+    fi
+}
+
+# Verifies the downloaded binary against the expected hash baked in by the release pipeline.
+# No-op when no expected hash is set (running the script from main).
+verify_checksum() {
+    file="$1"; expected="$2"
+
+    if [ -z "$expected" ]; then
+        return
+    fi
+
+    actual=$(compute_sha256 "$file")
+    if [ -z "$actual" ]; then
+        rm -f "$file"
+        error "Cannot verify checksum: neither sha256sum nor shasum is available. Install one and re-run."
+    fi
+
+    if [ "$actual" != "$expected" ]; then
+        rm -f "$file"
+        error "Checksum verification failed. Expected: $expected, Got: $actual"
+    fi
+
+    info "Checksum verified."
 }
 
 # Download file
@@ -427,6 +490,9 @@ main() {
 
     info "Downloading from: $DOWNLOAD_URL"
     download "$DOWNLOAD_URL" "$TEMP_FILE"
+
+    EXPECTED_SHA256=$(get_expected_sha256 "$OS" "$ARCH")
+    verify_checksum "$TEMP_FILE" "$EXPECTED_SHA256"
 
     # Rename and make executable
     FINAL_FILE=$(get_final_binary_path "$OS")


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Release workflow populated checksum variables into install scripts during releases
* Added checksum verification to PowerShell installer, failing on mismatch
* Added checksum verification to POSIX shell installer, required hash utilities


<sup>[More info](https://app.aikido.dev/featurebranch/scan/109911075?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->