### PR TITLE
E2E: Use pnpm 10 in node versions that don't support pnpm 11

### DIFF
--- a/.github/workflows/test-on-pr.yml
+++ b/.github/workflows/test-on-pr.yml
@@ -77,7 +77,7 @@ jobs:
           - node_version: "20"
             npm_version: "9.0.0"
             yarn_version: "latest"
-            pnpm_version: "latest"
+            pnpm_version: "10.0.0"
           # Version pinning scenario
           - node_version: "22"
             npm_version: "10.2.0"
@@ -87,7 +87,7 @@ jobs:
           - node_version: "18"
             npm_version: "latest"
             yarn_version: "latest"
-            pnpm_version: "latest"
+            pnpm_version: "10.0.0"
           # Future compatibility (becomes LTS October 2025)
           - node_version: "24"
             npm_version: "latest"


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Updated E2E workflow to pin pnpm to 10.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/114910362?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->