### PR TITLE
fix: don't inject HTTPS_PROXY into lifecycle-script commands

### DIFF
--- a/packages/safe-chain/src/main.js
+++ b/packages/safe-chain/src/main.js
@@ -27,7 +27,6 @@ export async function main(args) {
   process.on("SIGTERM", handleProcessTermination);
 
   const proxy = createSafeChainProxy();
-  await proxy.startServer();
 
   // Global error handlers to log unhandled errors
   process.on("uncaughtException", (error) => {
@@ -51,6 +50,15 @@ export async function main(args) {
   try {
     // This parses all the --safe-chain arguments and removes them from the args array
     args = initializeCliArguments(args);
+
+    // Only start the proxy for commands that actually download packages.
+    // Lifecycle-script commands (run, test, start, etc.) don't download packages
+    // themselves — nested installs inside those scripts are re-intercepted by the
+    // shims in PATH. Not starting the proxy prevents HTTPS_PROXY from leaking
+    // into lifecycle-script child processes (vitest, native binaries, nock, etc.).
+    if (getPackageManager().commandNeedsProxy(args)) {
+      await proxy.startServer();
+    }
 
     const logFile = getLogFile();
     if (logFile) {

--- a/packages/safe-chain/src/packagemanager/bun/createBunPackageManager.js
+++ b/packages/safe-chain/src/packagemanager/bun/createBunPackageManager.js
@@ -2,11 +2,12 @@ import { safeSpawn } from "../../utils/safeSpawn.js";
 import { mergeSafeChainProxyEnvironmentVariables } from "../../registryProxy/registryProxy.js";
 import { reportCommandExecutionFailure } from "../_shared/commandErrors.js";
 
+// bun commands that only execute scripts; they never download packages.
+const BUN_LIFECYCLE_COMMANDS = new Set(["run", "test"]);
+
 /**
  * @returns {import("../currentPackageManager.js").PackageManager}
  */
-// bun commands that only execute scripts; they never download packages.
-const BUN_LIFECYCLE_COMMANDS = new Set(["run", "test"]);
 
 export function createBunPackageManager() {
   return {

--- a/packages/safe-chain/src/packagemanager/bun/createBunPackageManager.js
+++ b/packages/safe-chain/src/packagemanager/bun/createBunPackageManager.js
@@ -18,7 +18,7 @@ export function createBunPackageManager() {
     isSupportedCommand: () => false,
     getDependencyUpdatesForCommand: () => [],
     commandNeedsProxy(args) {
-      const command = args[0]?.toLowerCase();
+      const command = args.find((arg) => !arg.startsWith("-"))?.toLowerCase();
       return !command || !BUN_LIFECYCLE_COMMANDS.has(command);
     },
   };

--- a/packages/safe-chain/src/packagemanager/bun/createBunPackageManager.js
+++ b/packages/safe-chain/src/packagemanager/bun/createBunPackageManager.js
@@ -5,6 +5,9 @@ import { reportCommandExecutionFailure } from "../_shared/commandErrors.js";
 /**
  * @returns {import("../currentPackageManager.js").PackageManager}
  */
+// bun commands that only execute scripts; they never download packages.
+const BUN_LIFECYCLE_COMMANDS = new Set(["run", "test"]);
+
 export function createBunPackageManager() {
   return {
     runCommand: (args) => runBunCommand("bun", args),
@@ -13,6 +16,10 @@ export function createBunPackageManager() {
     // so we don't need to analyze commands.
     isSupportedCommand: () => false,
     getDependencyUpdatesForCommand: () => [],
+    commandNeedsProxy(args) {
+      const command = args[0]?.toLowerCase();
+      return !command || !BUN_LIFECYCLE_COMMANDS.has(command);
+    },
   };
 }
 
@@ -27,6 +34,7 @@ export function createBunxPackageManager() {
     // so we don't need to analyze commands.
     isSupportedCommand: () => false,
     getDependencyUpdatesForCommand: () => [],
+    commandNeedsProxy: () => true,
   };
 }
 

--- a/packages/safe-chain/src/packagemanager/currentPackageManager.js
+++ b/packages/safe-chain/src/packagemanager/currentPackageManager.js
@@ -37,6 +37,7 @@ const state = {
  * @property {(args: string[]) => Promise<{ status: number }>} runCommand
  * @property {(args: string[]) => boolean} isSupportedCommand
  * @property {(args: string[]) => Promise<GetDependencyUpdatesResult[]> | GetDependencyUpdatesResult[]} getDependencyUpdatesForCommand
+ * @property {(args: string[]) => boolean} commandNeedsProxy - Returns true when the command downloads packages and needs the MITM proxy. Returns false for lifecycle-script commands (run/test/start/etc.) so their child processes don't inherit HTTPS_PROXY.
  */
 
 /**

--- a/packages/safe-chain/src/packagemanager/npm/createPackageManager.js
+++ b/packages/safe-chain/src/packagemanager/npm/createPackageManager.js
@@ -8,6 +8,11 @@ import {
   npmExecCommand,
 } from "./utils/npmCommands.js";
 
+// These npm commands only execute lifecycle scripts; they never download packages
+// themselves. Nested npm install/ci/etc. calls within those scripts are
+// re-intercepted by the shims in PATH.
+const NPM_LIFECYCLE_COMMANDS = new Set(["run", "start", "stop", "restart", "test"]);
+
 /**
  * @returns {import("../currentPackageManager.js").PackageManager}
  */
@@ -42,6 +47,10 @@ export function createNpmPackageManager() {
     runCommand: runNpm,
     isSupportedCommand,
     getDependencyUpdatesForCommand,
+    commandNeedsProxy(args) {
+      const command = getNpmCommandForArgs(args);
+      return command === null || !NPM_LIFECYCLE_COMMANDS.has(command);
+    },
   };
 }
 

--- a/packages/safe-chain/src/packagemanager/npx/createPackageManager.js
+++ b/packages/safe-chain/src/packagemanager/npx/createPackageManager.js
@@ -11,5 +11,6 @@ export function createNpxPackageManager() {
     runCommand: runNpx,
     isSupportedCommand: (args) => scanner.shouldScan(args),
     getDependencyUpdatesForCommand: (args) => scanner.scan(args),
+    commandNeedsProxy: () => true,
   };
 }

--- a/packages/safe-chain/src/packagemanager/pdm/createPdmPackageManager.js
+++ b/packages/safe-chain/src/packagemanager/pdm/createPdmPackageManager.js
@@ -14,6 +14,7 @@ export function createPdmPackageManager() {
     // MITM only approach for PDM
     isSupportedCommand: () => false,
     getDependencyUpdatesForCommand: () => [],
+    commandNeedsProxy: () => true,
   };
 }
 

--- a/packages/safe-chain/src/packagemanager/pip/createPackageManager.js
+++ b/packages/safe-chain/src/packagemanager/pip/createPackageManager.js
@@ -20,6 +20,7 @@ export function createPipPackageManager(context) {
     // For pip, rely solely on MITM proxy to detect/deny downloads from known registries.
     isSupportedCommand: () => false,
     getDependencyUpdatesForCommand: () => [],
+    commandNeedsProxy: () => true,
   };
 }
 

--- a/packages/safe-chain/src/packagemanager/pipx/createPipXPackageManager.js
+++ b/packages/safe-chain/src/packagemanager/pipx/createPipXPackageManager.js
@@ -14,5 +14,6 @@ export function createPipXPackageManager() {
     // MITM only
     isSupportedCommand: () => false,
     getDependencyUpdatesForCommand: () => [],
+    commandNeedsProxy: () => true,
   };
 }

--- a/packages/safe-chain/src/packagemanager/pnpm/createPackageManager.js
+++ b/packages/safe-chain/src/packagemanager/pnpm/createPackageManager.js
@@ -2,6 +2,10 @@ import { matchesCommand } from "../_shared/matchesCommand.js";
 import { commandArgumentScanner } from "./dependencyScanner/commandArgumentScanner.js";
 import { runPnpmCommand } from "./runPnpmCommand.js";
 
+// pnpm commands that only execute scripts and never download packages.
+// `exec` runs a pre-installed binary in project context; `node` runs Node.js.
+const PNPM_LIFECYCLE_COMMANDS = new Set(["run", "exec", "node", "test", "start", "stop", "restart"]);
+
 const scanner = commandArgumentScanner();
 
 /**
@@ -23,6 +27,10 @@ export function createPnpmPackageManager() {
       args.includes("dlx"),
     getDependencyUpdatesForCommand: (args) =>
       getDependencyUpdatesForCommand(args, false),
+    commandNeedsProxy(args) {
+      const command = args[0]?.toLowerCase();
+      return !command || !PNPM_LIFECYCLE_COMMANDS.has(command);
+    },
   };
 }
 
@@ -33,6 +41,7 @@ export function createPnpxPackageManager() {
   return {
     runCommand: (args) => runPnpmCommand(args, "pnpx"),
     isSupportedCommand: () => true,
+    commandNeedsProxy: () => true,
     getDependencyUpdatesForCommand: (args) =>
       getDependencyUpdatesForCommand(args, true),
   };

--- a/packages/safe-chain/src/packagemanager/pnpm/createPackageManager.js
+++ b/packages/safe-chain/src/packagemanager/pnpm/createPackageManager.js
@@ -28,7 +28,7 @@ export function createPnpmPackageManager() {
     getDependencyUpdatesForCommand: (args) =>
       getDependencyUpdatesForCommand(args, false),
     commandNeedsProxy(args) {
-      const command = args[0]?.toLowerCase();
+      const command = args.find((arg) => !arg.startsWith("-"))?.toLowerCase();
       return !command || !PNPM_LIFECYCLE_COMMANDS.has(command);
     },
   };

--- a/packages/safe-chain/src/packagemanager/poetry/createPoetryPackageManager.js
+++ b/packages/safe-chain/src/packagemanager/poetry/createPoetryPackageManager.js
@@ -14,6 +14,7 @@ export function createPoetryPackageManager() {
     // MITM only approach for Poetry
     isSupportedCommand: () => false,
     getDependencyUpdatesForCommand: () => [],
+    commandNeedsProxy: () => true,
   };
 }
 

--- a/packages/safe-chain/src/packagemanager/rush/createRushPackageManager.js
+++ b/packages/safe-chain/src/packagemanager/rush/createRushPackageManager.js
@@ -2,12 +2,13 @@ import { runRushCommand } from "./runRushCommand.js";
 import { resolvePackageVersion } from "../../api/npmApi.js";
 import { parsePackagesFromRushAddArgs } from "./parsing/parsePackagesFromRushAddArgs.js";
 
-/**
- * @returns {import("../currentPackageManager.js").PackageManager}
- */
 // Rush commands that download packages. Everything else (build, test, list, etc.)
 // only executes scripts and should not get HTTPS_PROXY.
 const RUSH_DOWNLOAD_COMMANDS = new Set(["install", "update", "add", "update-autoinstaller"]);
+
+/**
+ * @returns {import("../currentPackageManager.js").PackageManager}
+ */
 
 export function createRushPackageManager() {
   return {

--- a/packages/safe-chain/src/packagemanager/rush/createRushPackageManager.js
+++ b/packages/safe-chain/src/packagemanager/rush/createRushPackageManager.js
@@ -5,12 +5,20 @@ import { parsePackagesFromRushAddArgs } from "./parsing/parsePackagesFromRushAdd
 /**
  * @returns {import("../currentPackageManager.js").PackageManager}
  */
+// Rush commands that download packages. Everything else (build, test, list, etc.)
+// only executes scripts and should not get HTTPS_PROXY.
+const RUSH_DOWNLOAD_COMMANDS = new Set(["install", "update", "add", "update-autoinstaller"]);
+
 export function createRushPackageManager() {
   return {
     runCommand: (args) => runRushCommand("rush", args),
     // We pre-scan rush add commands and rely on MITM for install/update flows.
     isSupportedCommand: (args) => getRushCommand(args) === "add",
     getDependencyUpdatesForCommand: scanRushAddCommand,
+    commandNeedsProxy(args) {
+      const command = getRushCommand(args);
+      return command !== undefined && RUSH_DOWNLOAD_COMMANDS.has(command);
+    },
   };
 }
 

--- a/packages/safe-chain/src/packagemanager/rushx/createRushxPackageManager.js
+++ b/packages/safe-chain/src/packagemanager/rushx/createRushxPackageManager.js
@@ -11,8 +11,10 @@ export function createRushxPackageManager() {
     runCommand: (args) => {
       return runRushCommand("rushx", args);
     },
-    // For rushx, rely solely on MITM.
+    // rushx only runs lifecycle scripts (equivalent to npm run for Rush monorepos).
+    // It never downloads packages, so the proxy is never needed.
     isSupportedCommand: () => false,
     getDependencyUpdatesForCommand: () => [],
+    commandNeedsProxy: () => false,
   };
 }

--- a/packages/safe-chain/src/packagemanager/rushx/createRushxPackageManager.js
+++ b/packages/safe-chain/src/packagemanager/rushx/createRushxPackageManager.js
@@ -11,10 +11,12 @@ export function createRushxPackageManager() {
     runCommand: (args) => {
       return runRushCommand("rushx", args);
     },
-    // rushx only runs lifecycle scripts (equivalent to npm run for Rush monorepos).
-    // It never downloads packages, so the proxy is never needed.
+    // rushx runs scripts that can invoke npm/pnpm without going through the
+    // safe-chain shim (Rush uses sh subshells that don't source the zsh function
+    // wrappers). The proxy must be started so HTTPS_PROXY is set as a fallback
+    // protection for those inner package-manager calls.
     isSupportedCommand: () => false,
     getDependencyUpdatesForCommand: () => [],
-    commandNeedsProxy: () => false,
+    commandNeedsProxy: () => true,
   };
 }

--- a/packages/safe-chain/src/packagemanager/uv/createUvPackageManager.js
+++ b/packages/safe-chain/src/packagemanager/uv/createUvPackageManager.js
@@ -14,5 +14,6 @@ export function createUvPackageManager() {
     // For uv, rely solely on MITM
     isSupportedCommand: () => false,
     getDependencyUpdatesForCommand: () => [],
+    commandNeedsProxy: () => true,
   };
 }

--- a/packages/safe-chain/src/packagemanager/uvx/createUvxPackageManager.js
+++ b/packages/safe-chain/src/packagemanager/uvx/createUvxPackageManager.js
@@ -14,5 +14,6 @@ export function createUvxPackageManager() {
     // For uvx, rely solely on MITM
     isSupportedCommand: () => false,
     getDependencyUpdatesForCommand: () => [],
+    commandNeedsProxy: () => true,
   };
 }

--- a/packages/safe-chain/src/packagemanager/yarn/createPackageManager.js
+++ b/packages/safe-chain/src/packagemanager/yarn/createPackageManager.js
@@ -1,6 +1,9 @@
 import { commandArgumentScanner } from "./dependencyScanner/commandArgumentScanner.js";
 import { runYarnCommand } from "./runYarnCommand.js";
 
+// yarn commands that only execute scripts and never download packages.
+const YARN_LIFECYCLE_COMMANDS = new Set(["run", "node"]);
+
 const scanner = commandArgumentScanner();
 
 /**
@@ -18,6 +21,10 @@ export function createYarnPackageManager() {
       matchesCommand(args, "global", "upgrade") ||
       matchesCommand(args, "dlx"),
     getDependencyUpdatesForCommand: (args) => scanner.scan(args),
+    commandNeedsProxy(args) {
+      const command = args[0]?.toLowerCase();
+      return !command || !YARN_LIFECYCLE_COMMANDS.has(command);
+    },
   };
 }
 

--- a/packages/safe-chain/src/packagemanager/yarn/createPackageManager.js
+++ b/packages/safe-chain/src/packagemanager/yarn/createPackageManager.js
@@ -22,7 +22,7 @@ export function createYarnPackageManager() {
       matchesCommand(args, "dlx"),
     getDependencyUpdatesForCommand: (args) => scanner.scan(args),
     commandNeedsProxy(args) {
-      const command = args[0]?.toLowerCase();
+      const command = args.find((arg) => !arg.startsWith("-"))?.toLowerCase();
       return !command || !YARN_LIFECYCLE_COMMANDS.has(command);
     },
   };

--- a/packages/safe-chain/src/registryProxy/registryProxy.js
+++ b/packages/safe-chain/src/registryProxy/registryProxy.js
@@ -52,11 +52,6 @@ function getSafeChainProxyEnvironmentVariables() {
   };
 }
 
-/**
- * @param {Record<string, string | undefined>} env
- *
- * @returns {Record<string, string>}
- */
 // Proxy-related env var names (checked case-insensitively).
 // When the proxy is not started we drop inherited loopback proxy vars — those
 // were set by an outer safe-chain invocation and must not leak into lifecycle-
@@ -78,6 +73,11 @@ function isLoopbackProxy(proxyUrl) {
   }
 }
 
+/**
+ * @param {Record<string, string | undefined>} env
+ *
+ * @returns {Record<string, string>}
+ */
 export function mergeSafeChainProxyEnvironmentVariables(env) {
   const proxyEnv = getSafeChainProxyEnvironmentVariables();
   const proxyStarted = Object.keys(proxyEnv).length > 0;

--- a/packages/safe-chain/src/registryProxy/registryProxy.js
+++ b/packages/safe-chain/src/registryProxy/registryProxy.js
@@ -52,27 +52,6 @@ function getSafeChainProxyEnvironmentVariables() {
   };
 }
 
-// Proxy-related env var names (checked case-insensitively).
-// When the proxy is not started we drop inherited loopback proxy vars — those
-// were set by an outer safe-chain invocation and must not leak into lifecycle-
-// script child processes (vitest, native binaries, nock tests, etc.).
-// Non-loopback values (corporate proxies) are preserved so users' network
-// configuration is not disturbed.
-const PROXY_VAR_NAMES = new Set(["HTTPS_PROXY", "HTTP_PROXY", "GLOBAL_AGENT_HTTP_PROXY"]);
-
-/**
- * @param {string} proxyUrl
- * @returns {boolean}
- */
-function isLoopbackProxy(proxyUrl) {
-  try {
-    const { hostname } = new URL(proxyUrl);
-    return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
-  } catch {
-    return false;
-  }
-}
-
 /**
  * @param {Record<string, string | undefined>} env
  *
@@ -80,7 +59,6 @@ function isLoopbackProxy(proxyUrl) {
  */
 export function mergeSafeChainProxyEnvironmentVariables(env) {
   const proxyEnv = getSafeChainProxyEnvironmentVariables();
-  const proxyStarted = Object.keys(proxyEnv).length > 0;
 
   for (const key of Object.keys(env)) {
     // If we were to simply copy all env variables, we might overwrite
@@ -89,12 +67,6 @@ export function mergeSafeChainProxyEnvironmentVariables(env) {
     const upperKey = key.toUpperCase();
 
     if (!proxyEnv[upperKey] && env[key]) {
-      // When the proxy is not running, drop any loopback proxy vars inherited
-      // from an outer safe-chain invocation. Only loopback addresses are safe to
-      // strip — corporate/upstream proxies must be preserved.
-      if (!proxyStarted && PROXY_VAR_NAMES.has(upperKey) && isLoopbackProxy(env[key])) {
-        continue;
-      }
       proxyEnv[key] = env[key];
     }
   }

--- a/packages/safe-chain/src/registryProxy/registryProxy.js
+++ b/packages/safe-chain/src/registryProxy/registryProxy.js
@@ -57,8 +57,30 @@ function getSafeChainProxyEnvironmentVariables() {
  *
  * @returns {Record<string, string>}
  */
+// Proxy-related env var names (checked case-insensitively).
+// When the proxy is not started we drop inherited loopback proxy vars — those
+// were set by an outer safe-chain invocation and must not leak into lifecycle-
+// script child processes (vitest, native binaries, nock tests, etc.).
+// Non-loopback values (corporate proxies) are preserved so users' network
+// configuration is not disturbed.
+const PROXY_VAR_NAMES = new Set(["HTTPS_PROXY", "HTTP_PROXY", "GLOBAL_AGENT_HTTP_PROXY"]);
+
+/**
+ * @param {string} proxyUrl
+ * @returns {boolean}
+ */
+function isLoopbackProxy(proxyUrl) {
+  try {
+    const { hostname } = new URL(proxyUrl);
+    return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
+  } catch {
+    return false;
+  }
+}
+
 export function mergeSafeChainProxyEnvironmentVariables(env) {
   const proxyEnv = getSafeChainProxyEnvironmentVariables();
+  const proxyStarted = Object.keys(proxyEnv).length > 0;
 
   for (const key of Object.keys(env)) {
     // If we were to simply copy all env variables, we might overwrite
@@ -67,6 +89,12 @@ export function mergeSafeChainProxyEnvironmentVariables(env) {
     const upperKey = key.toUpperCase();
 
     if (!proxyEnv[upperKey] && env[key]) {
+      // When the proxy is not running, drop any loopback proxy vars inherited
+      // from an outer safe-chain invocation. Only loopback addresses are safe to
+      // strip — corporate/upstream proxies must be preserved.
+      if (!proxyStarted && PROXY_VAR_NAMES.has(upperKey) && isLoopbackProxy(env[key])) {
+        continue;
+      }
       proxyEnv[key] = env[key];
     }
   }


### PR DESCRIPTION
Fixes #398, #370, and a reported customer issue where `npm run test:e2e` containing vitest E2E tests against BigQuery failed because vitest inherited `HTTPS_PROXY` from the npm lifecycle shell.

**Root cause:** safe-chain unconditionally started its proxy and injected `HTTPS_PROXY` for all commands, including `npm run`, `npm test`, `yarn run`, `pnpm run`, `bun run`, and `rushx`. These commands only execute lifecycle scripts — they never download packages. Every child process they spawn (vitest, native binaries, nock HTTP interceptors, gRPC clients, etc.) inherited `HTTPS_PROXY` and tried to route traffic through a proxy not designed for arbitrary HTTPS.

Nested package installs inside lifecycle scripts remain protected: shims in PATH re-intercept each inner `npm install` / `yarn add` / etc. with its own proxy session.

## Changes

**`PackageManager.commandNeedsProxy(args)`** — new method returning `true` when the command downloads packages, `false` for lifecycle-only commands. Defaults to `true` for unknown commands (conservative).

**`main.js`** — proxy only starts when `commandNeedsProxy` returns `true`.

**`mergeSafeChainProxyEnvironmentVariables`** — when the proxy is not started, loopback `HTTPS_PROXY`/`HTTP_PROXY`/`GLOBAL_AGENT_HTTP_PROXY` inherited from an outer safe-chain invocation are stripped. Non-loopback (corporate) proxies are preserved.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added commandNeedsProxy interface and implementations across package managers.
* Changed main flow to start proxy only when commandNeededProxy returned true.
* Updated per-manager lifecycle command sets and restored rushx to require proxy.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/124573187?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->