### PR TITLE
Forward unchanged npm body verbatim to avoid busting cache

### DIFF
--- a/packages/safe-chain/src/registryProxy/interceptors/npm/modifyNpmInfo.js
+++ b/packages/safe-chain/src/registryProxy/interceptors/npm/modifyNpmInfo.js
@@ -75,13 +75,27 @@ export function modifyNpmInfoResponse(body, headers) {
       }))
       .filter((x) => x.version !== "created" && x.version !== "modified");
 
-    for (const { version, timestamp } of versions) {
-      const timestampValue = new Date(timestamp);
-      if (timestampValue > cutOff) {
-        deleteVersionFromJson(bodyJson, version);
-        clearCachingHeaders(headers);
-      }
+    const versionsToRemove = versions.filter(
+      ({ timestamp }) => new Date(timestamp) > cutOff
+    );
+
+    if (versionsToRemove.length === 0) {
+      // Nothing is newer than the cutoff, so the metadata is returned unchanged.
+      // Hand back the original buffer (and leave the caching headers in place) so
+      // npm and the registry can keep serving this response from cache instead of
+      // issuing a fresh read on every install. This is the common case, since most
+      // packages have no version published within the minimum-age window.
+      return body;
     }
+
+    for (const { version } of versionsToRemove) {
+      deleteVersionFromJson(bodyJson, version);
+    }
+
+    // The body changed, so the upstream validators (etag/last-modified) no longer
+    // describe it. Drop them so the client revalidates against the registry rather
+    // than trusting a cache entry that no longer matches what we served.
+    clearCachingHeaders(headers);
 
     if (hasLatestTag && !bodyJson["dist-tags"]["latest"]) {
       // The latest tag was removed because it contained a package younger than the treshold.

--- a/packages/safe-chain/src/registryProxy/interceptors/npm/modifyNpmInfo.js
+++ b/packages/safe-chain/src/registryProxy/interceptors/npm/modifyNpmInfo.js
@@ -80,11 +80,14 @@ export function modifyNpmInfoResponse(body, headers) {
     );
 
     if (versionsToRemove.length === 0) {
-      // Nothing is newer than the cutoff, so the metadata is returned unchanged.
-      // Hand back the original buffer (and leave the caching headers in place) so
-      // npm and the registry can keep serving this response from cache instead of
-      // issuing a fresh read on every install. This is the common case, since most
-      // packages have no version published within the minimum-age window.
+      // Nothing is newer than the cutoff, so the body is unchanged. Return the
+      // SAME buffer reference we were given (instead of re-serializing the parsed
+      // JSON). The proxy uses reference equality to detect "unchanged" and then
+      // forwards the upstream response verbatim, keeping its original encoding and
+      // caching headers (etag/cache-control) so npm and the registry can serve it
+      // from cache on later installs instead of issuing a fresh read. This is the
+      // common case, since most packages have no version published within the
+      // minimum-age window.
       return body;
     }
 

--- a/packages/safe-chain/src/registryProxy/interceptors/npm/npmInterceptor.minPackageAge.spec.js
+++ b/packages/safe-chain/src/registryProxy/interceptors/npm/npmInterceptor.minPackageAge.spec.js
@@ -179,6 +179,37 @@ describe("npmInterceptor minimum package age", async () => {
     assert.ok(!Object.keys(modifiedJson.versions).includes("3.0.0"));
   });
 
+  it("Should return the original body buffer unchanged when no version is too young", async () => {
+    minimumPackageAgeSettings = 5;
+    skipMinimumPackageAgeSetting = false;
+    minimumPackageAgeExclusionsSetting = [];
+    const packageUrl = "https://registry.npmjs.org/lodash";
+
+    const originalBuffer = Buffer.from(
+      JSON.stringify({
+        name: "lodash",
+        ["dist-tags"]: { latest: "2.0.0" },
+        versions: { ["1.0.0"]: {}, ["2.0.0"]: {} },
+        time: {
+          created: getDate(-365 * 24),
+          modified: getDate(-100),
+          ["1.0.0"]: getDate(-200),
+          ["2.0.0"]: getDate(-100), // well past the cutoff
+        },
+      })
+    );
+
+    const interceptor = npmInterceptorForUrl(packageUrl);
+    const requestHandler = await interceptor.handleRequest(packageUrl);
+    const result = requestHandler.modifyBody(originalBuffer, {
+      ["content-type"]: "application/json",
+    });
+
+    // The exact same buffer reference must be returned so the proxy can forward
+    // the upstream response verbatim and keep its caching headers intact.
+    assert.strictEqual(result, originalBuffer);
+  });
+
   it("Should set the package to the new latest non-preview release", async () => {
     minimumPackageAgeSettings = 5;
     const packageUrl = "https://registry.npmjs.org/lodash";

--- a/packages/safe-chain/src/registryProxy/mitmRequestHandler.js
+++ b/packages/safe-chain/src/registryProxy/mitmRequestHandler.js
@@ -208,13 +208,24 @@ function createProxyRequest(hostname, port, req, res, requestHandler) {
 
       proxyRes.on("end", () => {
         /** @type {Buffer} */
-        let buffer = Buffer.concat(chunks);
+        const originalBuffer = Buffer.concat(chunks);
+        let decodedBuffer = originalBuffer;
 
         if (proxyRes.headers["content-encoding"] === "gzip") {
-          buffer = gunzipSync(buffer);
+          decodedBuffer = gunzipSync(originalBuffer);
         }
 
-        buffer = requestHandler.modifyBody(buffer, headers);
+        const modifiedBuffer = requestHandler.modifyBody(decodedBuffer, headers);
+
+        if (modifiedBuffer === decodedBuffer) {
+          // The interceptor left the body unchanged, so forward the upstream
+          // response verbatim. Keeping the original encoding and caching headers
+          // (etag/cache-control) intact lets npm and the registry serve it from
+          // cache on later installs instead of issuing a fresh read.
+          res.writeHead(statusCode, headers);
+          res.end(originalBuffer);
+          return;
+        }
 
         // For rewritten responses, send the final body uncompressed.
         // This avoids mismatches between upstream compression metadata and the
@@ -224,9 +235,9 @@ function createProxyRequest(hostname, port, req, res, requestHandler) {
           ["content-length", "transfer-encoding", "content-encoding"],
           { caseInsensitive: true }
         ) || {};
-        rewrittenHeaders["content-length"] = String(buffer.byteLength);
+        rewrittenHeaders["content-length"] = String(modifiedBuffer.byteLength);
         res.writeHead(statusCode, rewrittenHeaders);
-        res.end(buffer);
+        res.end(modifiedBuffer);
       });
     } else {
       // If the response is not being modified, we can

--- a/packages/safe-chain/src/registryProxy/mitmRequestHandler.spec.js
+++ b/packages/safe-chain/src/registryProxy/mitmRequestHandler.spec.js
@@ -135,4 +135,69 @@ describe("mitmRequestHandler", async () => {
       String(resState.body.byteLength)
     );
   });
+
+  it("forwards the upstream response verbatim when the interceptor leaves the body unchanged", async () => {
+    const interceptor = {
+      handleRequest: async () => ({
+        blockResponse: undefined,
+        modifyRequestHeaders: (headers) => headers,
+        modifiesResponse: () => true,
+        // Return the same buffer reference we were given (no modification).
+        modifyBody: (body) => body,
+      }),
+    };
+
+    const req = {
+      url: "registry.npmjs.org:443",
+    };
+
+    const clientSocket = {
+      on: () => {},
+      write: () => {},
+      headersSent: false,
+      writable: true,
+      end: () => {},
+    };
+
+    mitmConnect(req, clientSocket, interceptor);
+
+    const resState = {
+      statusCode: undefined,
+      headers: undefined,
+      body: undefined,
+    };
+
+    const res = {
+      headersSent: false,
+      writeHead: (statusCode, headers) => {
+        resState.statusCode = statusCode;
+        resState.headers = headers;
+      },
+      end: (body) => {
+        resState.body = body;
+      },
+    };
+
+    const request = {
+      url: "/lodash",
+      headers: {},
+      method: "GET",
+      on: (event, handler) => {
+        if (event === "end") {
+          handler();
+        }
+      },
+    };
+
+    await capturedHandler(request, res);
+
+    // Caching/encoding headers are preserved so npm and the registry can keep
+    // serving the response from cache instead of re-reading on the next install.
+    assert.equal(resState.statusCode, 200);
+    assert.equal(resState.headers["content-encoding"], "gzip");
+    assert.equal(resState.headers["content-length"], "999");
+    assert.equal(resState.headers["transfer-encoding"], "chunked");
+    // The body is forwarded still-compressed, exactly as received from upstream.
+    assert.deepEqual(resState.body, zlib.gzipSync(Buffer.from("rewritten body")));
+  });
 });


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Returned original response buffer when no npm metadata changed
* Sent rewritten responses uncompressed and cleared upstream caching headers


<sup>[More info](https://app.aikido.dev/featurebranch/scan/124265335?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->