### PR TITLE
Use node version 22 instead of lts/* for npm stage publish

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -142,7 +142,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: "lts/*"
+          node-version: "22"
           registry-url: "https://registry.npmjs.org/"
 
       - name: Setup safe-chain


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Changed Node.js version for npm publish stage to 22


<sup>[More info](https://app.aikido.dev/featurebranch/scan/124679446?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->