### PR TITLE
Upgrade npm for staged publishing

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -144,6 +144,10 @@ jobs:
         with:
           node-version: "22"
           registry-url: "https://registry.npmjs.org/"
+      
+      - name: Upgrade npm for staged publishing
+        # npm stage publish requires npm 11.15.0+
+        run: npm i -g npm@11.15.0
 
       - name: Setup safe-chain
         run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci


### PR DESCRIPTION
Added step to upgrade npm to version 11.15.0 for staged publishing.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Upgraded npm to 11.15.0 for staged publishing in workflow


<sup>[More info](https://app.aikido.dev/featurebranch/scan/124686373?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->