### PR TITLE
Bump Endpoint to v1.6.1

### DIFF
--- a/install-scripts/install-endpoint-mac.sh
+++ b/install-scripts/install-endpoint-mac.sh
@@ -7,8 +7,8 @@
 set -e  # Exit on error
 
 # Configuration
-INSTALL_URL="https://github.com/AikidoSec/safechain-internals/releases/download/v1.5.9/EndpointProtection.pkg"
-DOWNLOAD_SHA256="1ff49693574de2fb4103e75a9c9b087a3cc90dbc16cd55456599314d97420841"
+INSTALL_URL="https://github.com/AikidoSec/safechain-internals/releases/download/v1.6.1/EndpointProtection.pkg"
+DOWNLOAD_SHA256="b54fc72fb1fc714d72870aaaf9f0c0a4b150b9212aabc7713e9611685762249f"
 TOKEN_FILE="/tmp/aikido_endpoint_token.txt"
 
 # Colors for output

--- a/install-scripts/install-endpoint-windows.ps1
+++ b/install-scripts/install-endpoint-windows.ps1
@@ -7,8 +7,8 @@ param(
 )
 
 # Configuration
-$InstallUrl = "https://github.com/AikidoSec/safechain-internals/releases/download/v1.5.9/EndpointProtection.msi"
-$DownloadSha256 = "bdc0ef7503e0095f6bcd785d0ec2ec3e9137f779c188182cf1d1acef1873fbc7"
+$InstallUrl = "https://github.com/AikidoSec/safechain-internals/releases/download/v1.6.1/EndpointProtection.msi"
+$DownloadSha256 = "f5a958cbc54b2bc82a5ed4b014aab84712bb9e8d8dbe4bad9b78a288ac14edb6"
 
 # Ensure TLS 1.2 is enabled for downloads
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Updated macOS installer URL and checksum to Endpoint v1.6.1
* Updated Windows installer URL and checksum to Endpoint v1.6.1


<sup>[More info](https://app.aikido.dev/featurebranch/scan/128166325?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->