### PR TITLE
add synthetic response on safe-chain-pi-test

### DIFF
--- a/packages/safe-chain/src/registryProxy/interceptors/interceptorBuilder.js
+++ b/packages/safe-chain/src/registryProxy/interceptors/interceptorBuilder.js
@@ -13,11 +13,13 @@ import { EventEmitter } from "events";
  * @property {(packageName: string, version: string, message: string) => void} blockMinimumAgeRequest
  * @property {(modificationFunc: (headers: NodeJS.Dict<string | string[]>) => NodeJS.Dict<string | string[]>) => void} modifyRequestHeaders
  * @property {(modificationFunc: (body: Buffer, headers: NodeJS.Dict<string | string[]> | undefined) => Buffer) => void} modifyBody
+ * @property {(response: {statusCode: number, headers: NodeJS.Dict<string>, body: Buffer}) => void} setSyntheticResponse
  * @property {() => RequestInterceptionHandler} build
  *
  *
  * @typedef {Object} RequestInterceptionHandler
  * @property {{statusCode: number, message: string} | undefined} blockResponse
+ * @property {{statusCode: number, headers: NodeJS.Dict<string>, body: Buffer} | undefined} syntheticResponse
  * @property {(headers: NodeJS.Dict<string | string[]> | undefined) => NodeJS.Dict<string | string[]> | undefined} modifyRequestHeaders
  * @property {() => boolean} modifiesResponse
  * @property {(body: Buffer, headers: NodeJS.Dict<string | string[]> | undefined) => Buffer} modifyBody
@@ -78,6 +80,8 @@ function buildInterceptor(requestHandlers) {
 function createRequestContext(targetUrl, eventEmitter) {
   /** @type {{statusCode: number, message: string} | undefined}  */
   let blockResponse = undefined;
+  /** @type {{statusCode: number, headers: NodeJS.Dict<string>, body: Buffer} | undefined} */
+  let syntheticResponse = undefined;
   /** @type {Array<(headers: NodeJS.Dict<string | string[]>) => NodeJS.Dict<string | string[]>>} */
   let reqheaderModificationFuncs = [];
   /** @type {Array<(body: Buffer, headers: NodeJS.Dict<string | string[]> | undefined) => Buffer>} */
@@ -161,6 +165,7 @@ function createRequestContext(targetUrl, eventEmitter) {
     // These functions are invoked in the proxy, allowing to apply the configured modifications
     return {
       blockResponse,
+      syntheticResponse,
       modifyRequestHeaders: modifyRequestHeaders,
       modifiesResponse: () => modifyBodyFuncs.length > 0,
       modifyBody,
@@ -174,6 +179,7 @@ function createRequestContext(targetUrl, eventEmitter) {
     blockMinimumAgeRequest: blockMinimumAgeRequestSetup,
     modifyRequestHeaders: (func) => reqheaderModificationFuncs.push(func),
     modifyBody: (func) => modifyBodyFuncs.push(func),
+    setSyntheticResponse: (response) => { syntheticResponse = response; },
     build,
   };
 }

--- a/packages/safe-chain/src/registryProxy/interceptors/pip/pipInterceptor.js
+++ b/packages/safe-chain/src/registryProxy/interceptors/pip/pipInterceptor.js
@@ -13,6 +13,10 @@ import {
   modifyPipInfoResponse,
   parsePipMetadataUrl,
 } from "./modifyPipInfo.js";
+import {
+  getTestPackageCanonicalName,
+  synthesizePipSimpleResponse,
+} from "./pipTestPackages.js";
 import { parsePipPackageFromUrl } from "./parsePipPackageUrl.js";
 
 const knownPipRegistries = [
@@ -55,6 +59,14 @@ function createPipRequestHandler(registry) {
     const minimumAgeChecksEnabled = !skipMinimumPackageAge();
     const metadataInfo = parsePipMetadataUrl(reqContext.targetUrl);
     const metadataPackageName = metadataInfo.packageName;
+
+    if (metadataPackageName) {
+      const canonical = getTestPackageCanonicalName(metadataPackageName);
+      if (canonical) {
+        reqContext.setSyntheticResponse(synthesizePipSimpleResponse(canonical));
+        return;
+      }
+    }
 
     if (
       minimumAgeChecksEnabled &&

--- a/packages/safe-chain/src/registryProxy/interceptors/pip/pipTestPackages.js
+++ b/packages/safe-chain/src/registryProxy/interceptors/pip/pipTestPackages.js
@@ -1,0 +1,43 @@
+import { normalizePipPackageName } from "../../../scanning/packageNameVariants.js";
+
+const TEST_PACKAGE_VERSION = "0.0.1";
+
+const TEST_PACKAGES = ["safe-chain-pi-test", "aikido-endpoint-test"];
+
+/**
+ * @param {string} packageName
+ * @returns {string | undefined} canonical hyphen-form name, or undefined if not a test package
+ */
+export function getTestPackageCanonicalName(packageName) {
+  const normalized = normalizePipPackageName(packageName);
+  return TEST_PACKAGES.find(
+    (p) => normalizePipPackageName(p) === normalized
+  );
+}
+
+/**
+ * @param {string} canonicalName hyphen-form name, e.g. "safe-chain-pi-test"
+ * @returns {{statusCode: number, headers: NodeJS.Dict<string>, body: Buffer}}
+ */
+export function synthesizePipSimpleResponse(canonicalName) {
+  const dist = canonicalName.replace(/-/g, "_");
+  const filename = `${dist}-${TEST_PACKAGE_VERSION}-py3-none-any.whl`;
+  const url = `https://files.pythonhosted.org/packages/00/00/${filename}`;
+  const html = [
+    `<!DOCTYPE html><html>`,
+    `<head><meta name="pypi:repository-version" content="1.0">`,
+    `<title>Links for ${canonicalName}</title></head>`,
+    `<body><h1>Links for ${canonicalName}</h1>`,
+    `<a href="${url}">${filename}</a><br>`,
+    `</body></html>`,
+  ].join("");
+  return {
+    statusCode: 200,
+    headers: {
+      "content-type": "text/html",
+      "cache-control": "no-cache, no-store, must-revalidate",
+      pragma: "no-cache",
+    },
+    body: Buffer.from(html),
+  };
+}

--- a/packages/safe-chain/src/registryProxy/mitmRequestHandler.js
+++ b/packages/safe-chain/src/registryProxy/mitmRequestHandler.js
@@ -82,6 +82,14 @@ function createHttpsServer(hostname, port, interceptor) {
         return;
       }
 
+      const syntheticResponse = requestInterceptor.syntheticResponse;
+      if (syntheticResponse) {
+        ui.writeVerbose(`Safe-chain: Serving synthetic response for ${targetUrl}`);
+        res.writeHead(syntheticResponse.statusCode, syntheticResponse.headers);
+        res.end(syntheticResponse.body);
+        return;
+      }
+
       // Collect request body
       forwardRequest(req, hostname, port, res, requestInterceptor);
     } catch (err) {

--- a/test/e2e/pip.e2e.spec.js
+++ b/test/e2e/pip.e2e.spec.js
@@ -152,6 +152,34 @@ describe("E2E: pip coverage", () => {
     );
   });
 
+  it(`safe-chain blocks installation of safe-chain-pi-test`, async () => {
+    const shell = await container.openShell("zsh");
+    const result = await shell.runCommand(
+      "pip3 install --break-system-packages safe-chain-pi-test --safe-chain-logging=verbose"
+    );
+
+    assert.match(
+      result.output,
+      /blocked [1-9]\d* malicious package downloads:/,
+      `Output did not include expected text. Output was:\n${result.output}`
+    );
+    assert.ok(
+      result.output.includes("safe_chain_pi_test@0.0.1"),
+      `Output did not include expected text. Output was:\n${result.output}`
+    );
+    assert.ok(
+      result.output.includes("Exiting without installing malicious packages."),
+      `Output did not include expected text. Output was:\n${result.output}`
+    );
+
+    const listResult = await shell.runCommand("pip3 list");
+    assert.ok(
+      !listResult.output.includes("safe-chain-pi-test") &&
+        !listResult.output.includes("safe_chain_pi_test"),
+      `Malicious package was installed despite safe-chain protection. Output of 'pip3 list' was:\n${listResult.output}`
+    );
+  });
+
   it(`python -m pip routes to aikido-pip (uses pip command)`, async () => {
     const shell = await container.openShell("zsh");
     const result = await shell.runCommand(


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 2 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added synthetic response support to interceptor builder and handler
* Implemented pip test-package synthetic responses and integrated into interceptor


<sup>[More info](https://app.aikido.dev/featurebranch/scan/131491953?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->