### PR TITLE
fix(yarn): add test, start, exec to lifecycle commands to prevent HTTPS_PROXY leak

### DIFF
--- a/packages/safe-chain/src/packagemanager/yarn/createPackageManager.js
+++ b/packages/safe-chain/src/packagemanager/yarn/createPackageManager.js
@@ -2,7 +2,7 @@ import { commandArgumentScanner } from "./dependencyScanner/commandArgumentScann
 import { runYarnCommand } from "./runYarnCommand.js";
 
 // yarn commands that only execute scripts and never download packages.
-const YARN_LIFECYCLE_COMMANDS = new Set(["run", "node"]);
+const YARN_LIFECYCLE_COMMANDS = new Set(["run", "node", "test", "start", "exec"]);
 
 const scanner = commandArgumentScanner();
 


### PR DESCRIPTION
## Problem

`commandNeedsProxy` for yarn only excludes `run` and `node` from the proxy lifecycle check:

```js
const YARN_LIFECYCLE_COMMANDS = new Set(["run", "node"]);
```

The shorthand commands `yarn test`, `yarn start`, and `yarn exec` are **not** in that set, so safe-chain starts the registry proxy for them and injects `HTTPS_PROXY` into the child process environment.

This is a problem for any project that runs integration/e2e tests using HTTP mocking libraries (e.g. **nock**) together with an HTTP client that auto-reads `HTTPS_PROXY` from the environment (e.g. **axios ≥ 1.x** via `proxy-from-env`).

## Root cause

When `yarn test` is intercepted by the safe-chain shim:

1. `commandNeedsProxy(["test"])` → `true` (bug: `"test"` ∉ `YARN_LIFECYCLE_COMMANDS`)
2. The registry proxy starts on `http://127.0.0.1:<port>`
3. `mergeSafeChainProxyEnvironmentVariables` injects `HTTPS_PROXY=http://127.0.0.1:<port>` into the spawned `yarn` process
4. axios (via `proxy-from-env`) reads `HTTPS_PROXY` and routes all outbound HTTPS requests through safe-chain's proxy
5. Requests to non-registry hosts (e.g. a mock API in tests) are forwarded by the proxy to a host that doesn't exist → connection error → test failures

nock-based mocks are bypassed entirely because axios never calls Node.js's patched `https.request` — it goes straight to the proxy via raw TCP, which nock allows (localhost is whitelisted).

## Reproduction

```
# project with the following setup:
# - jest + nock for HTTP mocking
# - axios for outbound HTTPS in application code
# - yarn 4.x managed by safe-chain shims

# In jest.setup.ts:
nock.disableNetConnect()
nock.enableNetConnect('127.0.0.1')

# In test:
nock('https://my-api.example.com').get('/data').reply(200, { ok: true })
const res = await request(app).get('/endpoint').expect(200) // → 500 instead
# nock interceptor is never consumed; axios silently routed to proxy
```

Without safe-chain shims the same test passes because `HTTPS_PROXY` is absent and axios calls `https.request` directly (which nock has patched).

## Fix

Add the three missing lifecycle shorthands to `YARN_LIFECYCLE_COMMANDS`:

| Command | What it does | Downloads packages? |
|---|---|---|
| `yarn test` | runs the `test` script from `package.json` | No |
| `yarn start` | runs the `start` script from `package.json` | No |
| `yarn exec <bin>` | runs a binary already in `node_modules/.bin` | No |

Any nested `yarn install` triggered inside one of those scripts is still re-intercepted by the shims on PATH, so registry-fetch coverage is not reduced.

Note: `yarn dlx` is intentionally **not** in this list — it downloads and executes packages on demand and must go through the proxy.

## Checklist

- [x] Fixes `yarn test` / `yarn start` / `yarn exec` proxy injection
- [x] `yarn dlx` and `yarn add` / `yarn install` are unaffected
- [x] Nested installs inside lifecycle scripts remain protected via PATH shims

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Added yarn lifecycle shorthands to prevent HTTPS_PROXY environment leakage


<sup>[More info](https://app.aikido.dev/featurebranch/scan/135287024?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->