### PR TITLE
Fix broken uninstall for safe-chain when it was installed through npm

### DIFF
--- a/install-scripts/uninstall-safe-chain.ps1
+++ b/install-scripts/uninstall-safe-chain.ps1
@@ -121,7 +121,12 @@ function Get-SafeChainInstallDir {
 }
 
 # Finds the installed safe-chain binary inside the resolved install directory.
-# Falls back to a validated safe-chain command when the expected file is missing.
+# Falls back to the safe-chain on PATH when the expected file is missing. The
+# PATH fallback is intentionally not restricted to the packaged-binary layout:
+# npm, nvm, volta, pnpm and bun all expose safe-chain through differently-shaped
+# shims (.cmd/.ps1/.exe), and teardown must run for all of them. (Install-dir
+# derivation, which feeds Remove-Item, stays strict and is handled separately by
+# Get-ReportedInstallDir / Get-InstallDirFromBinaryPath.)
 function Find-SafeChainBinary {
     param([string]$DotSafeChain)
 
@@ -136,7 +141,12 @@ function Find-SafeChainBinary {
         return $safeChainBin
     }
 
-    return Get-ValidatedSafeChainCommandPath
+    $command = Get-SafeChainCommand
+    if ($command -and -not [string]::IsNullOrWhiteSpace($command.Path)) {
+        return $command.Path
+    }
+
+    return $null
 }
 
 # Runs safe-chain teardown before removing the installation directory.

--- a/install-scripts/uninstall-safe-chain.sh
+++ b/install-scripts/uninstall-safe-chain.sh
@@ -153,7 +153,12 @@ get_reported_install_dir() {
 }
 
 # Locates the installed safe-chain binary to use for teardown.
-# Checks the discovered install dir first, then falls back to a validated PATH entry.
+# Prefers the binary inside the discovered install dir, then falls back to the
+# safe-chain on PATH. The PATH fallback is intentionally not restricted to the
+# packaged-binary layout: npm, nvm, volta, pnpm and bun all expose safe-chain
+# through differently-shaped shims, and teardown must run for all of them.
+# (Install-dir derivation, which feeds the rm -rf, stays strict and is handled
+# separately by get_reported_install_dir / derive_install_dir_from_binary.)
 find_installed_safe_chain_binary() {
     dot_safe_chain="$1"
 
@@ -163,7 +168,7 @@ find_installed_safe_chain_binary() {
         return 0
     fi
 
-    command_path=$(get_validated_safe_chain_command_path || true)
+    command_path=$(get_safe_chain_command_path || true)
     if [ -n "$command_path" ]; then
         printf '%s\n' "$command_path"
         return 0


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added automatic uninstall routines for npm, Volta and nvm installations

**🐛 Bugfixes**
* Allowed PATH shim fallback for teardown when binary layout differed


<sup>[More info](https://app.aikido.dev/featurebranch/scan/135684176?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->