### PR TITLE
Bump Endpoint to v1.7.5

### DIFF
--- a/install-scripts/install-endpoint-mac.sh
+++ b/install-scripts/install-endpoint-mac.sh
@@ -7,8 +7,8 @@
 set -e  # Exit on error
 
 # Configuration
-INSTALL_URL="https://github.com/AikidoSec/safechain-internals/releases/download/v1.7.1/EndpointProtection.pkg"
-DOWNLOAD_SHA256="d804b7ac5aacfcae098a4f19035a23acb9630aa64328e02091f3d4250179e62a"
+INSTALL_URL="https://github.com/AikidoSec/safechain-internals/releases/download/v1.7.5/EndpointProtection.pkg"
+DOWNLOAD_SHA256="355439d41f45f29451eb459c9c176439d2928424ceebd81b96454c9972defb3d"
 TOKEN_FILE="/tmp/aikido_endpoint_token.txt"
 
 # Colors for output

--- a/install-scripts/install-endpoint-windows.ps1
+++ b/install-scripts/install-endpoint-windows.ps1
@@ -8,8 +8,8 @@ param(
 )
 
 # Configuration
-$InstallUrl = "https://github.com/AikidoSec/safechain-internals/releases/download/v1.7.1/EndpointProtection.msi"
-$DownloadSha256 = "bf43270a6c2ed889121eb58c18d555d4cfef4ba1960d4789905039bfc0dd2316"
+$InstallUrl = "https://github.com/AikidoSec/safechain-internals/releases/download/v1.7.5/EndpointProtection.msi"
+$DownloadSha256 = "36304bcb637c329901ea88e3db389d107227aa8ec8e76964697dec48626dd6d2"
 
 # Ensure TLS 1.2 is enabled for downloads
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Updated Windows installer URL and SHA256 to Endpoint v1.7.5
* Updated macOS installer URL and SHA256 to Endpoint v1.7.5


<sup>[More info](https://app.aikido.dev/featurebranch/scan/135699481?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->