### PR TITLE
Bump Endpoint to v1.7.7

### DIFF
--- a/install-scripts/install-endpoint-mac.sh
+++ b/install-scripts/install-endpoint-mac.sh
@@ -7,8 +7,8 @@
 set -e  # Exit on error
 
 # Configuration
-INSTALL_URL="https://github.com/AikidoSec/safechain-internals/releases/download/v1.7.6/EndpointProtection.pkg"
-DOWNLOAD_SHA256="39ab46226c4cfc837e7c2972d8d2a4c7bcf9dbdb6e2bc90d2d3aee9f0160f143"
+INSTALL_URL="https://github.com/AikidoSec/safechain-internals/releases/download/v1.7.7/EndpointProtection.pkg"
+DOWNLOAD_SHA256="b8711c3b95135daaee87631fdffd4995e34765c08d5d6a12b850ea3f01a8121f"
 TOKEN_FILE="/tmp/aikido_endpoint_token.txt"
 
 # Colors for output

--- a/install-scripts/install-endpoint-windows.ps1
+++ b/install-scripts/install-endpoint-windows.ps1
@@ -8,8 +8,8 @@ param(
 )
 
 # Configuration
-$InstallUrl = "https://github.com/AikidoSec/safechain-internals/releases/download/v1.7.6/EndpointProtection.msi"
-$DownloadSha256 = "2bed90eee41975805da77dd713749d9b497f42681637c4468a0188c5cf7ab966"
+$InstallUrl = "https://github.com/AikidoSec/safechain-internals/releases/download/v1.7.7/EndpointProtection.msi"
+$DownloadSha256 = "9611355cc85f60e2930977877c3ee88a8b041198520d30815afd5bc870f1d207"
 
 # Ensure TLS 1.2 is enabled for downloads
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Updated Windows installer download URL and SHA256 checksum to v1.7.7
* Updated macOS installer download URL and SHA256 checksum to v1.7.7


<sup>[More info](https://app.aikido.dev/featurebranch/scan/137353634?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->