### PR TITLE
Bump Endpoint to v1.7.9

### DIFF
--- a/install-scripts/install-endpoint-mac.sh
+++ b/install-scripts/install-endpoint-mac.sh
@@ -7,8 +7,8 @@
 set -e  # Exit on error
 
 # Configuration
-INSTALL_URL="https://github.com/AikidoSec/safechain-internals/releases/download/v1.7.12/EndpointProtection.pkg"
-DOWNLOAD_SHA256="5704185c4019cb83c2f6a55f7f4015775bde252222f0fbab28721f5675c2c22f"
+INSTALL_URL="https://github.com/AikidoSec/safechain-internals/releases/download/v1.7.9/EndpointProtection.pkg"
+DOWNLOAD_SHA256="0916a59089aaa38c1a5087e10e2f76a604ffd797008f1fe7f29283f04878e2c1"
 TOKEN_FILE="/tmp/aikido_endpoint_token.txt"
 
 # Colors for output

--- a/install-scripts/install-endpoint-windows.ps1
+++ b/install-scripts/install-endpoint-windows.ps1
@@ -8,8 +8,8 @@ param(
 )
 
 # Configuration
-$InstallUrl = "https://github.com/AikidoSec/safechain-internals/releases/download/v1.7.12/EndpointProtection.msi"
-$DownloadSha256 = "4864f311dfb7b3df7ddea1218cbbd0286d88c323cc983c8f5fcd113eed293500"
+$InstallUrl = "https://github.com/AikidoSec/safechain-internals/releases/download/v1.7.9/EndpointProtection.msi"
+$DownloadSha256 = "58adf33cef7af4015d89548698f419f65fe88c1ee72ca4f6da38753b9fca24a3"
 
 # Ensure TLS 1.2 is enabled for downloads
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Updated macOS installer to download Endpoint Protection v1.7.9.
* Updated Windows installer to download Endpoint Protection v1.7.9.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/143767594?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->