### PR TITLE
fix: trust OS system CA store in registry proxy

### DIFF
--- a/packages/safe-chain/src/registryProxy/certBundle.js
+++ b/packages/safe-chain/src/registryProxy/certBundle.js
@@ -11,6 +11,31 @@ import { ui } from "../environment/userInteraction.js";
 /** @type {string | null} */
 let bundlePath = null;
 
+/** @type {string[] | null} */
+let combinedCerts = null;
+
+/**
+ * Read the OS system trust store when the runtime supports it.
+ *
+ * `tls.getCACertificates("system")` was added in Node 22.15 / 23.5, so on older
+ * runtimes the function is absent and this is a silent no-op. Some platforms can
+ * also throw while enumerating the store, so any failure yields an empty array.
+ *
+ * @returns {string[]} PEM-encoded system CA certificates (empty if unavailable)
+ */
+function getSystemCaCertificates() {
+  try {
+    // Cast: tls.getCACertificates was added in Node 22.15 / 23.5 and may be
+    // missing from the installed @types/node, so reach it dynamically.
+    const getCACertificates = /** @type {any} */ (tls).getCACertificates;
+    if (typeof getCACertificates !== "function") return [];
+    const certs = getCACertificates("system");
+    return Array.isArray(certs) ? certs : [];
+  } catch {
+    return [];
+  }
+}
+
 /**
  * Check if a PEM string contains only parsable cert blocks.
  * @param {string} pem - PEM-encoded certificate string
@@ -52,8 +77,9 @@ function isParsable(pem) {
  * - Safe Chain CA (for MITM of known registries)
  * - Mozilla roots via certifi (for public HTTPS)
  * - Node's built-in root certificates (fallback)
+ * - The OS system trust store (self-signed / internal-CA certs the user installed)
  * - User's custom certificates (if NODE_EXTRA_CA_CERTS environment variable is set)
- * 
+ *
  * @returns {string} Path to the combined CA bundle PEM file
  */
 export function getCombinedCaBundlePath() {
@@ -94,7 +120,15 @@ export function getCombinedCaBundlePath() {
     // Ignore if unavailable
   }
 
-  // 4) User's NODE_EXTRA_CA_CERTS (if set)
+  // 4) OS system trust store (self-signed / internal-CA certs installed by the
+  //    user in the OS: ca-certificates.crt, macOS keychain, Windows cert store).
+  //    No-op on Node < 22.15 where tls.getCACertificates is absent.
+  for (const systemPem of getSystemCaCertificates()) {
+    if (typeof systemPem !== "string") continue;
+    if (isParsable(systemPem)) parts.push(systemPem.trim());
+  }
+
+  // 5) User's NODE_EXTRA_CA_CERTS (if set)
   const userCertPath = process.env.NODE_EXTRA_CA_CERTS;
   if (userCertPath) {
     const userPem = readUserCertificateFile(userCertPath);
@@ -106,10 +140,26 @@ export function getCombinedCaBundlePath() {
     }
   }
 
-  const combined = parts.filter(Boolean).join("\n");
+  combinedCerts = parts.filter(Boolean);
+  const combined = combinedCerts.join("\n");
   bundlePath = path.join(os.tmpdir(), `safe-chain-ca-bundle-${Date.now()}.pem`);
   fs.writeFileSync(bundlePath, combined, { encoding: "utf8" });
   return bundlePath;
+}
+
+/**
+ * Return the same combined trust as {@link getCombinedCaBundlePath}, but as an
+ * array of PEM strings suitable for the `ca` option of an https request. Passing
+ * this to `https.request` lets the proxy's own upstream TLS trust the OS store
+ * (plus certifi + Node roots + NODE_EXTRA_CA_CERTS) without weakening validation.
+ *
+ * @returns {string[]} PEM-encoded certificates
+ */
+export function getCombinedCaCertificates() {
+  if (!combinedCerts) {
+    getCombinedCaBundlePath();
+  }
+  return combinedCerts || [];
 }
 
 /**
@@ -124,6 +174,7 @@ export function cleanupCertBundle() {
     }
     bundlePath = null;
   }
+  combinedCerts = null;
 }
 
 /**

--- a/packages/safe-chain/src/registryProxy/certBundle.spec.js
+++ b/packages/safe-chain/src/registryProxy/certBundle.spec.js
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import tls from "node:tls";
+import forge from "node-forge";
 
 // Utility to remove the generated bundle so the module rebuilds it on demand
 function removeBundleIfExists() {
@@ -374,6 +375,102 @@ describe("certBundle.getCombinedCaBundlePath with user certs", () => {
       // Should contain base bundle (Safe Chain + Mozilla + Node roots) but NOT user cert
       const certCount = (contents.match(/-----BEGIN CERTIFICATE-----/g) || []).length;
       assert.strictEqual(certCount, baselineCertCount, `Traversal path ${badPath} should be rejected; base bundle only (no user cert added)`);
+    }
+  });
+});
+
+// Generate a genuinely distinct self-signed CA PEM so we can assert on its
+// presence unambiguously (it is not one of Node's built-in roots).
+function makeUniqueCaPem(commonName) {
+  const keys = forge.pki.rsa.generateKeyPair(2048);
+  const cert = forge.pki.createCertificate();
+  cert.publicKey = keys.publicKey;
+  cert.serialNumber = "02";
+  cert.validity.notBefore = new Date();
+  cert.validity.notAfter = new Date();
+  cert.validity.notAfter.setFullYear(cert.validity.notBefore.getFullYear() + 1);
+  const attrs = [{ name: "commonName", value: commonName }];
+  cert.setSubject(attrs);
+  cert.setIssuer(attrs);
+  cert.sign(keys.privateKey, forge.md.sha256.create());
+  return forge.pki.certificateToPem(cert).trim();
+}
+
+// These tests import the real certBundle (no module mock) so it shares the same
+// node:tls singleton as this spec, letting us drive getCACertificates directly.
+// tls module mocking does not reach a builtin default import in the child graph.
+describe("certBundle system trust store (#270)", () => {
+  const originalGetCACertificates = Object.getOwnPropertyDescriptor(tls, "getCACertificates");
+
+  beforeEach(() => {
+    mock.restoreAll();
+    delete process.env.NODE_EXTRA_CA_CERTS;
+    removeBundleIfExists();
+  });
+
+  function restoreTls() {
+    if (originalGetCACertificates) {
+      Object.defineProperty(tls, "getCACertificates", originalGetCACertificates);
+    } else {
+      // @ts-ignore - property may not exist on older runtimes
+      delete tls.getCACertificates;
+    }
+  }
+
+  it("adds OS system-store certs when tls.getCACertificates is available", async () => {
+    const systemCert = makeUniqueCaPem("safe-chain-system-store-test");
+    // @ts-ignore - override the system-store lookup for the test
+    tls.getCACertificates = () => [systemCert];
+    try {
+      const { getCombinedCaBundlePath, cleanupCertBundle } = await import("./certBundle.js");
+      cleanupCertBundle(); // clear any cached bundle from earlier tests
+      const contents = fs.readFileSync(getCombinedCaBundlePath(), "utf8");
+      assert.ok(
+        contents.includes(systemCert),
+        "Combined bundle should include the OS system-store certificate"
+      );
+    } finally {
+      restoreTls();
+    }
+  });
+
+  it("is a silent no-op (no throw, no system cert) when tls.getCACertificates is absent", async () => {
+    const systemCert = makeUniqueCaPem("safe-chain-absent-api-test");
+    // Simulate Node < 22.15 where the API does not exist.
+    // @ts-ignore - intentionally removing to exercise the feature guard
+    delete tls.getCACertificates;
+    try {
+      const { getCombinedCaBundlePath, cleanupCertBundle } = await import("./certBundle.js");
+      cleanupCertBundle();
+      let bundlePath;
+      assert.doesNotThrow(() => {
+        bundlePath = getCombinedCaBundlePath();
+      }, "Absent getCACertificates must not throw");
+      const contents = fs.readFileSync(bundlePath, "utf8");
+      assert.match(contents, /-----BEGIN CERTIFICATE-----/, "Bundle still built from other sources");
+      assert.ok(!contents.includes(systemCert), "No system cert added when the API is unavailable");
+    } finally {
+      restoreTls();
+    }
+  });
+
+  it("getCombinedCaCertificates returns a PEM array including the system store", async () => {
+    const systemCert = makeUniqueCaPem("safe-chain-array-export-test");
+    // @ts-ignore - override the system-store lookup for the test
+    tls.getCACertificates = () => [systemCert];
+    try {
+      const { getCombinedCaCertificates, cleanupCertBundle } = await import("./certBundle.js");
+      cleanupCertBundle();
+      const certs = getCombinedCaCertificates();
+      assert.ok(Array.isArray(certs), "Returns an array");
+      assert.ok(certs.length > 0, "Array is non-empty");
+      assert.ok(
+        certs.every((c) => typeof c === "string" && c.includes("BEGIN CERTIFICATE")),
+        "Every entry is a PEM string"
+      );
+      assert.ok(certs.includes(systemCert), "Array includes the system-store certificate");
+    } finally {
+      restoreTls();
     }
   });
 });

--- a/packages/safe-chain/src/registryProxy/mitmRequestHandler.js
+++ b/packages/safe-chain/src/registryProxy/mitmRequestHandler.js
@@ -1,5 +1,6 @@
 import https from "https";
 import { generateCertForHost } from "./certUtils.js";
+import { getCombinedCaCertificates } from "./certBundle.js";
 import { HttpsProxyAgent } from "https-proxy-agent";
 import { ui } from "../environment/userInteraction.js";
 import { gunzipSync } from "zlib";
@@ -179,13 +180,18 @@ function createProxyRequest(hostname, port, req, res, requestHandler) {
   }
   headers = requestHandler.modifyRequestHeaders(headers);
 
-  /** @type {import("http").RequestOptions} */
+  /** @type {import("https").RequestOptions} */
   const options = {
     hostname: hostname,
     port: port || 443,
     path: req.url,
     method: req.method,
     headers: { ...headers },
+    // Trust the combined store (Node roots + certifi + OS system store +
+    // NODE_EXTRA_CA_CERTS) so upstream registries served by an OS-installed
+    // self-signed CA validate instead of failing with "unable to get local
+    // issuer certificate". Verification stays on (rejectUnauthorized default).
+    ca: getCombinedCaCertificates(),
   };
 
   const httpsProxy = process.env.HTTPS_PROXY || process.env.https_proxy;

--- a/packages/safe-chain/src/registryProxy/mitmRequestHandler.spec.js
+++ b/packages/safe-chain/src/registryProxy/mitmRequestHandler.spec.js
@@ -56,6 +56,12 @@ describe("mitmRequestHandler", async () => {
     },
   });
 
+  mock.module("./certBundle.js", {
+    namedExports: {
+      getCombinedCaCertificates: () => ["SYSTEM-STORE-CA-PEM"],
+    },
+  });
+
   mock.module("https-proxy-agent", {
     namedExports: {
       HttpsProxyAgent: class {},
@@ -128,6 +134,11 @@ describe("mitmRequestHandler", async () => {
     await capturedHandler(request, res);
 
     assert.equal(capturedOptions.hostname, "pypi.org");
+    // The upstream request must trust the combined CA store (Node roots +
+    // certifi + OS system store + NODE_EXTRA_CA_CERTS) so OS-installed
+    // self-signed registries validate instead of returning Bad Gateway (#270).
+    assert.ok(Array.isArray(capturedOptions.ca), "upstream request passes a ca array");
+    assert.ok(capturedOptions.ca.length > 0, "ca array is non-empty");
     assert.equal(resState.statusCode, 200);
     assert.equal(resState.headers["transfer-encoding"], undefined);
     assert.equal(

--- a/packages/safe-chain/src/registryProxy/plainHttpProxy.js
+++ b/packages/safe-chain/src/registryProxy/plainHttpProxy.js
@@ -1,5 +1,6 @@
 import * as http from "http";
 import * as https from "https";
+import { getCombinedCaCertificates } from "./certBundle.js";
 import { ui } from "../environment/userInteraction.js";
 
 /**
@@ -57,10 +58,19 @@ function handleRequest(req, res) {
     return;
   }
 
+  /** @type {import("https").RequestOptions} */
+  const requestOptions = { method: req.method, headers: req.headers };
+  if (protocol === https) {
+    // Trust the OS system store (plus certifi + Node roots + NODE_EXTRA_CA_CERTS)
+    // on the direct-HTTPS fallback so OS-trusted self-signed hosts don't fail
+    // with "Bad Gateway: unable to get local issuer certificate".
+    requestOptions.ca = getCombinedCaCertificates();
+  }
+
   const proxyRequest = protocol
     .request(
       req.url,
-      { method: req.method, headers: req.headers },
+      requestOptions,
       (proxyRes) => {
         if (!proxyRes.statusCode) {
           ui.writeError("Safe-chain: Proxy response missing status code");

--- a/packages/safe-chain/src/registryProxy/plainHttpProxy.spec.js
+++ b/packages/safe-chain/src/registryProxy/plainHttpProxy.spec.js
@@ -1,0 +1,86 @@
+import { describe, it, mock } from "node:test";
+import assert from "node:assert";
+
+describe("plainHttpProxy ca option (#270)", async () => {
+  const httpsStore = {};
+  const httpStore = {};
+
+  function makeRequestStub(store) {
+    return (_url, options) => {
+      store.options = options;
+      return {
+        on() {
+          return this;
+        },
+        write() {},
+        end() {},
+        destroy() {},
+      };
+    };
+  }
+
+  mock.module("https", {
+    namedExports: { request: makeRequestStub(httpsStore) },
+    defaultExport: { request: makeRequestStub(httpsStore) },
+  });
+
+  mock.module("http", {
+    namedExports: { request: makeRequestStub(httpStore) },
+    defaultExport: { request: makeRequestStub(httpStore) },
+  });
+
+  mock.module("./certBundle.js", {
+    namedExports: {
+      getCombinedCaCertificates: () => ["SYSTEM-STORE-CA-PEM"],
+    },
+  });
+
+  mock.module("../environment/userInteraction.js", {
+    namedExports: {
+      ui: { writeVerbose: () => {}, writeError: () => {}, writeWarning: () => {} },
+    },
+  });
+
+  const { handleHttpProxyRequest } = await import("./plainHttpProxy.js");
+
+  function makeReqRes(url) {
+    const req = {
+      url,
+      method: "GET",
+      headers: {},
+      on() {},
+      pipe() {},
+    };
+    const res = {
+      headersSent: false,
+      writable: true,
+      writeHead() {},
+      end() {},
+      destroy() {},
+      on() {},
+    };
+    return { req, res };
+  }
+
+  it("passes the combined ca array on the direct-HTTPS fallback", () => {
+    httpsStore.options = undefined;
+    const { req, res } = makeReqRes("https://app.local.test/pkg");
+    handleHttpProxyRequest(req, res);
+
+    assert.ok(httpsStore.options, "https.request was called");
+    assert.deepStrictEqual(
+      httpsStore.options.ca,
+      ["SYSTEM-STORE-CA-PEM"],
+      "https fallback trusts the combined CA store"
+    );
+  });
+
+  it("does not set ca on the plain-HTTP path", () => {
+    httpStore.options = undefined;
+    const { req, res } = makeReqRes("http://example.test/pkg");
+    handleHttpProxyRequest(req, res);
+
+    assert.ok(httpStore.options, "http.request was called");
+    assert.strictEqual(httpStore.options.ca, undefined, "plain HTTP has no ca option");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #270. With safe-chain active, TLS to a host whose CA lives only in the OS
system trust store (a self-signed / internal CA installed in the macOS keychain,
the Windows cert store, or `ca-certificates.crt`) fails with `unable to get local
issuer certificate` / `Bad Gateway`, even though the same command works when run
without safe-chain. As noted in the thread (`SanderDeclerck`: "safe-chain
shouldn't interfere with the os trust store"), the root cause is that Node does
not load the OS trust store by default, and safe-chain's proxy never adds it, so
its upstream TLS only trusts Node's built-in Mozilla roots + certifi +
`NODE_EXTRA_CA_CERTS`, never the certs the user installed in the OS.

This adds the OS system store as an additional trusted CA source, without
weakening validation (`rejectUnauthorized` stays on, default):

- `certBundle.js`: adds a fifth CA source via `tls.getCACertificates("system")`,
  so the bundle exported to child package-manager processes trusts the OS store.
  A new `getCombinedCaCertificates()` returns the same combined trust as a PEM
  array for the proxy to use.
- `mitmRequestHandler.js` and `plainHttpProxy.js`: pass that combined trust as
  the `ca` option on the proxy's own upstream `https.request`, so MITM'd
  registries and the direct-HTTPS fallback validate OS-trusted self-signed
  upstreams instead of returning `Bad Gateway`. Because `ca` still includes the
  Node roots + certifi, public registries (e.g. npmjs.org) keep validating
  normally.

## Why this matters

Users behind an internal CA or hitting a self-signed registry currently have to
work around safe-chain (`NO_PROXY=...`, `command pnpm ...`) or drop it entirely,
which defeats its purpose. This makes safe-chain trust the same certificates the
host already trusts, so `wait-on https://app.local.test`, custom npm registries,
and internal-CA hosts work through the proxy the same as they do without it.

`tls.getCACertificates` was added in Node 22.15 / 23.5. It is feature-detected
(`typeof tls.getCACertificates === "function"`) and wrapped in try/catch, so on
older runtimes it is a silent no-op with unchanged behavior. This keeps the
project's stated Node 18+ support intact.

Tests: extended `certBundle.spec.js` (system-store cert included when the API is
present; no throw / no cert added when absent; `getCombinedCaCertificates`
returns the PEM array), asserted the `ca` array is passed on the MITM upstream
request (`mitmRequestHandler.spec.js`) and the direct-HTTPS fallback (new
`plainHttpProxy.spec.js`). Full suite: 739 passing. `npm run lint` and
`npm run typecheck` pass.

Closes #270


<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added OS system CA extraction and exported combined CA array
* Passed combined CA to proxy upstream HTTPS requests for validation


<sup>[More info](https://app.aikido.dev/featurebranch/scan/147099763?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->