### PR TITLE
Bump Endpoint to v1.7.17

### DIFF
--- a/install-scripts/install-endpoint-mac.sh
+++ b/install-scripts/install-endpoint-mac.sh
@@ -7,8 +7,8 @@
 set -e  # Exit on error
 
 # Configuration
-INSTALL_URL="https://github.com/AikidoSec/safechain-internals/releases/download/v1.7.16/EndpointProtection.pkg"
-DOWNLOAD_SHA256="93ae44d5dae710348487e100da88418b9955f5d6f7b391e96c1841bd6a76c905"
+INSTALL_URL="https://github.com/AikidoSec/safechain-internals/releases/download/v1.7.17/EndpointProtection.pkg"
+DOWNLOAD_SHA256="79539b355dee4d33a20839b42ae612524d7dd94e88d14c6f30529f25a2e2f0b2"
 TOKEN_FILE="/tmp/aikido_endpoint_token.txt"
 
 # Colors for output

--- a/install-scripts/install-endpoint-windows.ps1
+++ b/install-scripts/install-endpoint-windows.ps1
@@ -8,8 +8,8 @@ param(
 )
 
 # Configuration
-$InstallUrl = "https://github.com/AikidoSec/safechain-internals/releases/download/v1.7.16/EndpointProtection.msi"
-$DownloadSha256 = "52885040b52aaef8bc8271ca89988f8a0c42c97fa5350829da6d501bdebc1866"
+$InstallUrl = "https://github.com/AikidoSec/safechain-internals/releases/download/v1.7.17/EndpointProtection.msi"
+$DownloadSha256 = "407371af42cda32f01456e9280c587eb0d95d9f40e8cda4416927f831eca3ab6"
 
 # Ensure TLS 1.2 is enabled for downloads
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Updated macOS installer to download Endpoint v1.7.17 and checksum.
* Updated Windows installer to download Endpoint v1.7.17 and checksum.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/147860577?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->