### PR TITLE
allow -debug to windows endpoint isntall that adds /L*V debugging fla…

### DIFF
--- a/install-scripts/install-endpoint-windows.ps1
+++ b/install-scripts/install-endpoint-windows.ps1
@@ -5,16 +5,8 @@
 param(
     [string]$token,
     [switch]${is-mdm},
-    [switch]$debug,
-    [Parameter(ValueFromRemainingArguments = $true)]
-    [string[]]$RemainingArgs
+    [switch]$debug
 )
-
-# PowerShell only binds single-dash switches (e.g. -debug); accept a stray
-# "--debug" too, since it's a common typo/convention from other CLIs.
-if ($RemainingArgs -contains '--debug' -or $RemainingArgs -contains '-debug') {
-    $debug = $true
-}
 
 # Configuration
 $InstallUrl = "https://github.com/AikidoSec/safechain-internals/releases/download/v1.7.17/EndpointProtection.msi"

--- a/install-scripts/install-endpoint-windows.ps1
+++ b/install-scripts/install-endpoint-windows.ps1
@@ -1,11 +1,20 @@
 # Downloads and installs Aikido Endpoint Protection on Windows
 #
-# Usage: iex "& { $(iwr '<url>' -UseBasicParsing) } -token <TOKEN> [-is-mdm]"
+# Usage: iex "& { $(iwr '<url>' -UseBasicParsing) } -token <TOKEN> [-is-mdm] [-debug]"
 
 param(
     [string]$token,
-    [switch]${is-mdm}
+    [switch]${is-mdm},
+    [switch]$debug,
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$RemainingArgs
 )
+
+# PowerShell only binds single-dash switches (e.g. -debug); accept a stray
+# "--debug" too, since it's a common typo/convention from other CLIs.
+if ($RemainingArgs -contains '--debug' -or $RemainingArgs -contains '-debug') {
+    $debug = $true
+}
 
 # Configuration
 $InstallUrl = "https://github.com/AikidoSec/safechain-internals/releases/download/v1.7.17/EndpointProtection.msi"
@@ -55,6 +64,7 @@ function Install-Endpoint {
 
     # 2. Download the .msi
     $msiFile = Join-Path $env:TEMP "AikidoEndpoint-$([System.Guid]::NewGuid().ToString('N')).msi"
+    $logFile = Join-Path $env:TEMP "AikidoEndpoint-$([System.Guid]::NewGuid().ToString('N')).log"
 
     Write-Info "Downloading Aikido Endpoint Protection..."
     try {
@@ -81,7 +91,22 @@ function Install-Endpoint {
         if (${is-mdm}) {
             $msiArgs += "IS_MDM=1"
         }
+        if ($debug) {
+            Write-Info "Debug logging enabled. MSI log: $logFile"
+            $msiArgs += @("/L*V", "`"$logFile`"")
+        }
         $process = Start-Process -FilePath "msiexec" -ArgumentList $msiArgs -Wait -PassThru
+
+        if ($debug) {
+            Write-Info "MSI installer log output:"
+            if (Test-Path $logFile) {
+                Get-Content -Path $logFile | Write-Host
+            }
+            else {
+                Write-Host "[WARN] No log file was produced at $logFile" -ForegroundColor Yellow
+            }
+        }
+
         if ($process.ExitCode -ne 0) {
             Write-Error-Custom "MSI installer failed (exit code: $($process.ExitCode))."
         }
@@ -92,6 +117,9 @@ function Install-Endpoint {
         # Cleanup
         if (Test-Path $msiFile) {
             Remove-Item -Path $msiFile -Force -ErrorAction SilentlyContinue
+        }
+        if (Test-Path $logFile) {
+            Remove-Item -Path $logFile -Force -ErrorAction SilentlyContinue
         }
     }
 }


### PR DESCRIPTION
…g to msiexec

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added -debug option that enabled verbose MSI logging and cleanup

**📚 Documentation**
* Updated script usage comment to advertise the new -debug flag


<sup>[More info](https://app.aikido.dev/featurebranch/scan/148000956?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->