### PR TITLE
Bump Endpoint to v1.7.21

### DIFF
--- a/install-scripts/install-endpoint-mac.sh
+++ b/install-scripts/install-endpoint-mac.sh
@@ -7,8 +7,8 @@
 set -e  # Exit on error
 
 # Configuration
-INSTALL_URL="https://github.com/AikidoSec/safechain-internals/releases/download/v1.7.19/EndpointProtection.pkg"
-DOWNLOAD_SHA256="1ff4936107339245ef8cf9b7b6bbcba50a5f397f1fa947e008c46b00a8c4ed63"
+INSTALL_URL="https://github.com/AikidoSec/safechain-internals/releases/download/v1.7.21/EndpointProtection.pkg"
+DOWNLOAD_SHA256="a51202cd56e83332872d6c01b8cb4a04ec2f963e88078b93e0863e85babe9114"
 TOKEN_FILE="/tmp/aikido_endpoint_token.txt"
 
 # Colors for output

--- a/install-scripts/install-endpoint-windows.ps1
+++ b/install-scripts/install-endpoint-windows.ps1
@@ -9,8 +9,8 @@ param(
 )
 
 # Configuration
-$InstallUrl = "https://github.com/AikidoSec/safechain-internals/releases/download/v1.7.19/EndpointProtection.msi"
-$DownloadSha256 = "a5a5bd5a2661d354737c1f678fec68db00c16d7773606596c324532065a1f40c"
+$InstallUrl = "https://github.com/AikidoSec/safechain-internals/releases/download/v1.7.21/EndpointProtection.msi"
+$DownloadSha256 = "a948c1b8194b9aec011df37b349a840fcf749ab34042197f8acdfeeaf9472d11"
 
 # Ensure TLS 1.2 is enabled for downloads
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Updated macOS installer URL and SHA256 to v1.7.21 release
* Updated Windows installer URL and SHA256 to v1.7.21 release


<sup>[More info](https://app.aikido.dev/featurebranch/scan/153388895?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->