### PR TITLE
allow -debug to windows endpoint uninstall that adds /L*V debugging flag to msiexec

### DIFF
--- a/install-scripts/uninstall-endpoint-windows.ps1
+++ b/install-scripts/uninstall-endpoint-windows.ps1
@@ -1,6 +1,10 @@
 # Uninstalls Aikido Endpoint Protection endpoint on Windows
 #
-# Usage: iex (iwr '<url>' -UseBasicParsing)
+# Usage: iex "& { $(iwr '<url>' -UseBasicParsing) } [-debug]"
+
+param(
+    [switch]$debug
+)
 
 # Configuration
 $AppName = "Aikido Endpoint Protection"
@@ -40,14 +44,39 @@ function Uninstall-Endpoint {
     }
 
     $productCode = $app.IdentifyingNumber
+    $logFile = Join-Path $env:TEMP "AikidoEndpoint-$([System.Guid]::NewGuid().ToString('N')).log"
 
-    Write-Info "Uninstalling Aikido Endpoint Protection..."
-    $process = Start-Process -FilePath "msiexec" -ArgumentList "/x", $productCode, "/qn", "/norestart" -Wait -PassThru
-    if ($process.ExitCode -ne 0) {
-        Write-Error-Custom "Uninstall failed (exit code: $($process.ExitCode))."
+    try {
+        Write-Info "Uninstalling Aikido Endpoint Protection..."
+        $msiArgs = @("/x", $productCode, "/qn", "/norestart")
+        if ($debug) {
+            Write-Info "Debug logging enabled. MSI log: $logFile"
+            $msiArgs += @("/L*V", "`"$logFile`"")
+        }
+        $process = Start-Process -FilePath "msiexec" -ArgumentList $msiArgs -Wait -PassThru
+
+        if ($debug) {
+            Write-Info "MSI uninstaller log output:"
+            if (Test-Path $logFile) {
+                Get-Content -Path $logFile | Write-Host
+            }
+            else {
+                Write-Host "[WARN] No log file was produced at $logFile" -ForegroundColor Yellow
+            }
+        }
+
+        if ($process.ExitCode -ne 0) {
+            Write-Error-Custom "Uninstall failed (exit code: $($process.ExitCode))."
+        }
+
+        Write-Info "Aikido Endpoint Protection uninstalled successfully!"
     }
-
-    Write-Info "Aikido Endpoint Protection uninstalled successfully!"
+    finally {
+        # Cleanup
+        if (Test-Path $logFile) {
+            Remove-Item -Path $logFile -Force -ErrorAction SilentlyContinue
+        }
+    }
 }
 
 # Run uninstallation


### PR DESCRIPTION
Same as #533, but for the Windows endpoint uninstall script.

Adds an optional `-debug` switch to `install-scripts/uninstall-endpoint-windows.ps1`:
- passes `/L*V <logfile>` to `msiexec /x` for verbose MSI logging
- prints the log to the console after the uninstall runs (with a warning if no log was produced)
- cleans up the log file in a `finally` block

Default behavior is unchanged when `-debug` is not passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 2 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added -debug option enabling verbose MSI logging and cleanup


<sup>[More info](https://app.aikido.dev/featurebranch/scan/154321397?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->