### PR TITLE
fix: Look up packages via map 

### DIFF
--- a/packages/safe-chain/src/scanning/newPackagesDatabaseBuilder.js
+++ b/packages/safe-chain/src/scanning/newPackagesDatabaseBuilder.js
@@ -35,6 +35,19 @@ function getCurrentFeedSource() {
  */
 export function buildNewPackagesDatabase(newPackagesList) {
   const ecosystem = getEcoSystem();
+  const expectedSource = getCurrentFeedSource();
+
+  /** @type {Map<string, import("../api/aikido.js").NewPackageEntry>} */
+  const entriesByNameAndVersion = new Map();
+  for (const pkg of newPackagesList) {
+    if (pkg.source && pkg.source.toLowerCase() !== expectedSource) {
+      continue;
+    }
+    const key = `${pkg.package_name} ${pkg.version}`;
+    if (!entriesByNameAndVersion.has(key)) {
+      entriesByNameAndVersion.set(key, pkg);
+    }
+  }
 
   /**
    * @param {string | undefined} name
@@ -49,22 +62,15 @@ export function buildNewPackagesDatabase(newPackagesList) {
     const cutOff = new Date(
       new Date().getTime() - getMinimumPackageAgeHours() * 3600 * 1000
     );
-    const expectedSource = getCurrentFeedSource();
-    const candidateNames = getEquivalentPackageNames(name, ecosystem);
 
-    const entry = newPackagesList.find(
-      (pkg) =>
-        (!pkg.source || pkg.source.toLowerCase() === expectedSource) &&
-        candidateNames.includes(pkg.package_name) &&
-        pkg.version === version
-    );
-
-    if (!entry) {
-      return false;
+    for (const candidateName of getEquivalentPackageNames(name, ecosystem)) {
+      const entry = entriesByNameAndVersion.get(`${candidateName} ${version}`);
+      if (entry) {
+        return new Date(entry.released_on * 1000) > cutOff;
+      }
     }
 
-    const releasedOn = new Date(entry.released_on * 1000);
-    return releasedOn > cutOff;
+    return false;
   }
 
   return { isNewlyReleasedPackage };

--- a/packages/safe-chain/src/scanning/newPackagesDatabaseBuilder.spec.js
+++ b/packages/safe-chain/src/scanning/newPackagesDatabaseBuilder.spec.js
@@ -154,6 +154,62 @@ describe("buildNewPackagesDatabase", () => {
 
       ecosystem = "js";
     });
+  });
 
+  describe("scan cost", () => {
+    function makeCountingFeed(size, counter) {
+      return Array.from({ length: size }, (_, i) => {
+        const packageName = `filler-package-${i}`;
+        return {
+          version: "9.9.9",
+          released_on: hoursAgo(1000),
+          get package_name() {
+            counter.reads++;
+            return packageName;
+          },
+        };
+      });
+    }
+
+    it("reads the feed once, not once per lookup", () => {
+      const feedSize = 50;
+      const lookups = 10;
+      const counter = { reads: 0 };
+      const db = buildNewPackagesDatabase(makeCountingFeed(feedSize, counter));
+
+      for (let i = 0; i < lookups; i++) {
+        db.isNewlyReleasedPackage("example", "1.82.1");
+      }
+
+      assert.ok(
+        counter.reads <= feedSize + lookups,
+        `read feed entries ${counter.reads} times for ${lookups} lookups ` +
+          `against a ${feedSize}-entry feed; expected at most ${feedSize + lookups}`,
+      );
+    });
+
+    it("lookup cost does not grow with feed size", () => {
+      const lookups = 10;
+      const readsDuringLookups = (feedSize) => {
+        const counter = { reads: 0 };
+        const db = buildNewPackagesDatabase(
+          makeCountingFeed(feedSize, counter),
+        );
+        const afterBuild = counter.reads;
+        for (let i = 0; i < lookups; i++) {
+          db.isNewlyReleasedPackage("example", `1.${i}.0`);
+        }
+        return counter.reads - afterBuild;
+      };
+
+      const small = readsDuringLookups(20);
+      const large = readsDuringLookups(80);
+
+      assert.ok(
+        large <= small + lookups * 2,
+        `lookups read the feed ${small} times at 20 entries and ${large} at 80; ` +
+          `per-lookup cost scales with feed size`,
+      );
+    });
   });
 });


### PR DESCRIPTION
The `isNewlyReleasedPackage` function is called for every file in every release of a package. 

For certain packages, like `grpcio`, which has over 10k files over 276 releases:

```bash
❯  curl -s -H 'Accept: application/vnd.pypi.simple.v1+json' https://pypi.org/simple/grpcio/ \
  | jq '{file_entries: (.files | length), releases: (.versions | length)}'
{
  "file_entries": 10366,
  "releases": 276
}
```

and at this moment, the `newPackagesList` is about 57k entries, which means 10k calls that perform `newPackagesList.find` for almost 600 million comparisons, since only one of the `grpcio` releases is in the 7 day window stored in `newPackagesList`. This is causing timeouts for us when performing a `uv sync`.

With this change, we index the feed into a Map, keyed by package name and version, so that the 10k calls should be just O(1) map lookups.

With a warm uv cache, deleting `.venv` and `uv.lock` before each run, a `uv sync` in a project we have went from taking ~60 seconds to about 6-7 seconds to finish, with this change.

> [!NOTE]
> Not fixed here is another issue, which is the fact that safe-chain is checking if a version is a new release for each file in the release. `grpcio` should in theory just need to be checked 276 times as well, further improving the performance.
