### PR TITLE
harden: sanitize child_process call in runPipCommand.js...

### DIFF
--- a/packages/safe-chain/src/packagemanager/pip/runPipCommand.js
+++ b/packages/safe-chain/src/packagemanager/pip/runPipCommand.js
@@ -8,7 +8,6 @@ import fsSync from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import ini from "ini";
-import { spawn } from "child_process";
 import { reportCommandExecutionFailure } from "../_shared/commandErrors.js";
 
 /**
@@ -78,20 +77,18 @@ export async function runPip(command, args) {
   // Check if we should bypass safe-chain (python/python3 without -m pip)
   if (shouldBypassSafeChain(command, args)) {
     ui.writeVerbose(`Safe-chain: Bypassing safe-chain for non-pip invocation: ${command} ${args.join(" ")}`);
-    // Spawn the ORIGINAL command with ORIGINAL args
-    return new Promise((_resolve) => {
-      const proc = spawn(command, args, { stdio: "inherit" });
-      proc.on("exit", (/** @type {number | null} */ code) => {
-        ui.writeVerbose(`${command} ${args.join(" ")} exited with status ${code}`);
-        ui.writeBufferedLogsAndStopBuffering();
-        process.exit(code ?? 0);
-      });
-      proc.on("error", (/** @type {Error} */ err) => {
-        ui.writeError(`Error executing command: ${err.message}`);
-        ui.writeBufferedLogsAndStopBuffering();
-        process.exit(1);
-      });
-    });
+    // Spawn the ORIGINAL command with ORIGINAL args using the vetted safeSpawn
+    // wrapper, which validates the command name before executing it.
+    try {
+      const result = await safeSpawn(command, args, { stdio: "inherit" });
+      ui.writeVerbose(`${command} ${args.join(" ")} exited with status ${result.status}`);
+      ui.writeBufferedLogsAndStopBuffering();
+      process.exit(result.status);
+    } catch (/** @type any */ err) {
+      ui.writeError(`Error executing command: ${err.message}`);
+      ui.writeBufferedLogsAndStopBuffering();
+      process.exit(1);
+    }
   }
 
   try {


### PR DESCRIPTION
## Summary
Harden input handling in `packages/safe-chain/src/packagemanager/pip/runPipCommand.js` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | javascript.lang.security.detect-child-process.detect-child-process |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `javascript.lang.security.detect-child-process.detect-child-process` |
| **File** | `packages/safe-chain/src/packagemanager/pip/runPipCommand.js:83` |
| **Assessment** | Defensive hardening |

**Description**: Detected calls to child_process from a function argument `command`. This could lead to a command injection if the input is user controllable. Try to avoid calls to child_process, and if it is needed ensure user input is correctly sanitized or sandboxed. 

## Threat Model Context

This is a private Node.js application (not published to npm). Vulnerabilities affect this application's own runtime only.

## Changes
- `packages/safe-chain/src/packagemanager/pip/runPipCommand.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
